### PR TITLE
feat: init monorepo with npm workspaces and shared types

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm info @react-native-async-storage/async-storage version)",
+      "Bash(npm info react-native-safe-area-context version)",
+      "Bash(npm info react-native-screens version)",
+      "Bash(npm info @react-navigation/bottom-tabs version)",
+      "Bash(npm info @react-navigation/stack version)",
+      "Bash(npm info @nestjs/config version)",
+      "Bash(npm info @nestjs/swagger version)",
+      "Bash(npm info class-validator version)",
+      "Bash(npm info class-transformer version)",
+      "Bash(npm info bcryptjs version)",
+      "Bash(git add .)"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Mini Personal Finance Advisor
+
+An AI-first mobile finance app built with **React Native (Expo)**, **NestJS**, and **Anthropic Claude**.
+
+## Monorepo Structure
+
+```
+financial-advisor/
+├── apps/
+│   ├── api/        # NestJS backend (port 3000)
+│   └── mobile/     # Expo React Native app (port 8081)
+└── packages/
+    └── shared/     # Shared TypeScript types
+```
+
+## Quick Start
+
+```bash
+# Install all dependencies
+npm install
+
+# Start the API (requires PostgreSQL running)
+npm run api
+
+# Start the mobile app
+npm run mobile
+
+# Run DB migrations
+npm run db:migrate
+```
+
+## Environment Setup
+
+Copy `apps/api/.env.example` to `apps/api/.env` and fill in:
+- `DATABASE_URL` – PostgreSQL connection string
+- `ANTHROPIC_API_KEY` – your Anthropic API key
+- `JWT_ACCESS_SECRET` / `JWT_REFRESH_SECRET` – random secrets
+
+## Sprint 1 Features
+- Automated transaction categorization via AI
+- Spending insights (weekly/monthly)
+- Savings goal recommendations
+- AI-generated weekly challenges

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "financial-advisor",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "api": "npm run start:dev --workspace=apps/api",
+    "mobile": "npx expo start --project-directory apps/mobile",
+    "db:migrate": "npm run prisma:migrate --workspace=apps/api",
+    "db:studio": "npm run prisma:studio --workspace=apps/api",
+    "build:shared": "npm run build --workspace=packages/shared"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.2"
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@financial-advisor/shared",
+  "version": "1.0.0",
+  "description": "Shared TypeScript types for the Financial Advisor monorepo",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.2"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/shared/src/types/auth.types.ts
+++ b/packages/shared/src/types/auth.types.ts
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------
+// Auth Types
+// Shared between the NestJS API and the React Native mobile app.
+// ---------------------------------------------------------------------------
+
+export interface RegisterDto {
+  email: string;
+  password: string;
+  name?: string;
+}
+
+export interface LoginDto {
+  email: string;
+  password: string;
+}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+export interface AuthResponse {
+  user: AuthUser;
+  tokens: AuthTokens;
+}
+
+export interface RefreshTokenDto {
+  refreshToken: string;
+}

--- a/packages/shared/src/types/auth.types.ts
+++ b/packages/shared/src/types/auth.types.ts
@@ -3,6 +3,13 @@
 // Shared between the NestJS API and the React Native mobile app.
 // ---------------------------------------------------------------------------
 
+/**
+ * How the user authenticated.
+ * LOCAL = email/password. Add GOOGLE and APPLE when OAuth is implemented.
+ * The Prisma User model stores this so we never need a schema migration for OAuth.
+ */
+export type AuthProvider = 'LOCAL' | 'GOOGLE' | 'APPLE';
+
 export interface RegisterDto {
   email: string;
   password: string;
@@ -14,6 +21,15 @@ export interface LoginDto {
   password: string;
 }
 
+/** Payload for OAuth sign-in (Google / Apple). Password is not required. */
+export interface OAuthLoginDto {
+  provider: Exclude<AuthProvider, 'LOCAL'>;
+  /** ID token from the OAuth provider (verified server-side) */
+  idToken: string;
+  email: string;
+  name?: string;
+}
+
 export interface AuthTokens {
   accessToken: string;
   refreshToken: string;
@@ -23,6 +39,7 @@ export interface AuthUser {
   id: string;
   email: string;
   name?: string;
+  authProvider: AuthProvider;
 }
 
 export interface AuthResponse {

--- a/packages/shared/src/types/challenge.types.ts
+++ b/packages/shared/src/types/challenge.types.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// Challenge Types
+// Weekly AI-generated spending challenge shown on the Challenge screen.
+// ---------------------------------------------------------------------------
+
+export type ChallengeStatus = 'ACTIVE' | 'COMPLETED' | 'FAILED';
+
+export interface Challenge {
+  id: string;
+  userId: string;
+  /** Plain-text challenge description, e.g. "Spend less than $50 on dining out this week." */
+  description: string;
+  weekStart: string; // ISO-8601
+  weekEnd: string;   // ISO-8601
+  status: ChallengeStatus;
+  createdAt: string;
+}

--- a/packages/shared/src/types/goal.types.ts
+++ b/packages/shared/src/types/goal.types.ts
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------------------
+// Goal Types
+// Savings goal set by the user, with an AI-generated recommendation.
+// ---------------------------------------------------------------------------
+
+// DTO for creating or updating a goal
+export interface CreateGoalDto {
+  description: string;
+  targetAmount: number;
+  /** Optional target date in ISO-8601 format */
+  deadline?: string;
+}
+
+export interface Goal {
+  id: string;
+  userId: string;
+  description: string;
+  targetAmount: number;
+  deadline: string | null; // ISO-8601
+  /** Cached AI recommendation text; null if not yet generated */
+  aiRecommendation: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,0 +1,10 @@
+// ---------------------------------------------------------------------------
+// Barrel export for all shared types.
+// Import from '@financial-advisor/shared' in both the API and mobile app.
+// ---------------------------------------------------------------------------
+
+export * from './auth.types';
+export * from './transaction.types';
+export * from './goal.types';
+export * from './insight.types';
+export * from './challenge.types';

--- a/packages/shared/src/types/insight.types.ts
+++ b/packages/shared/src/types/insight.types.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// Insight Types
+// AI-generated spending analysis text returned from /insights endpoints.
+// ---------------------------------------------------------------------------
+
+export type InsightPeriod = 'weekly' | 'monthly';
+
+export interface Insight {
+  period: InsightPeriod;
+  /** The AI-generated plain-text summary (2-3 sentences, actionable) */
+  summary: string;
+  /** ISO-8601 date range this insight covers */
+  from: string;
+  to: string;
+  /** When this insight was generated */
+  generatedAt: string;
+}

--- a/packages/shared/src/types/transaction.types.ts
+++ b/packages/shared/src/types/transaction.types.ts
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------
+// Transaction Types
+// Represents a single income or expense entry with AI-assigned category.
+// ---------------------------------------------------------------------------
+
+/**
+ * Valid spending/income categories the AI can assign.
+ * Extend this list if more granularity is needed later.
+ */
+export type TransactionCategory =
+  | 'Food'
+  | 'Transport'
+  | 'Bills'
+  | 'Entertainment'
+  | 'Shopping'
+  | 'Health'
+  | 'Income'
+  | 'Other';
+
+export type TransactionType = 'INCOME' | 'EXPENSE';
+
+// DTO sent by the mobile app when creating a transaction
+export interface CreateTransactionDto {
+  description: string;
+  amount: number;
+  type: TransactionType;
+  /** Optional override — if omitted, AI will categorize automatically */
+  category?: TransactionCategory;
+  /** Optional date; defaults to now on the server */
+  date?: string; // ISO-8601
+}
+
+// Full transaction object returned from the API
+export interface Transaction {
+  id: string;
+  userId: string;
+  description: string;
+  amount: number;
+  type: TransactionType;
+  category: TransactionCategory;
+  /** 0–1 confidence score from the AI categorizer; null if user-specified */
+  aiConfidence: number | null;
+  date: string; // ISO-8601
+  createdAt: string;
+}
+
+// Query params for GET /transactions
+export interface GetTransactionsQuery {
+  type?: TransactionType;
+  category?: TransactionCategory;
+  from?: string; // ISO-8601 date
+  to?: string;   // ISO-8601 date
+  page?: number;
+  limit?: number;
+}
+
+// Paginated response wrapper
+export interface PaginatedTransactions {
+  data: Transaction[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+// Aggregated totals grouped by category (used by the Dashboard)
+export interface TransactionSummary {
+  category: TransactionCategory;
+  total: number;
+  count: number;
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "target": "ES2022",
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
## Summary
- Root `package.json` with npm workspaces (`apps/*`, `packages/*`)
- Root `tsconfig.json` and `.gitignore`
- `@financial-advisor/shared` package with all Sprint 1 TypeScript types

## Branch Flow
`feat/issue-1-monorepo-scaffold` → **`dev`** → `staging` → `main`

Closes #1