### PR TITLE
feat(api): implement AiService with Anthropic SDK

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
     "@financial-advisor/shared": "*",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.3",
@@ -36,7 +37,8 @@
     "pg": "^8.20.0",
     "prisma": "^7.4.2",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -46,10 +48,10 @@
     "@nestjs/testing": "^11.0.1",
     "@types/bcrypt": "^5.0.2",
     "@types/express": "^5.0.0",
-    "@types/pg": "^8.18.0",
-    "@types/passport-jwt": "^4.0.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
+    "@types/passport-jwt": "^4.0.1",
+    "@types/pg": "^8.18.0",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/apps/api/src/ai/ai.module.ts
+++ b/apps/api/src/ai/ai.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { AiService } from './ai.service';
 
-// TODO(Issue #7): AiService with Anthropic SDK implemented in issue #7
 @Module({
   providers: [AiService],
   exports: [AiService],

--- a/apps/api/src/ai/ai.service.spec.ts
+++ b/apps/api/src/ai/ai.service.spec.ts
@@ -1,0 +1,271 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import Anthropic from '@anthropic-ai/sdk';
+import { AiService } from './ai.service';
+import type { Transaction } from '@financial-advisor/shared';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('@anthropic-ai/sdk');
+jest.mock('@anthropic-ai/sdk/helpers/zod', () => ({
+  zodOutputFormat: jest.fn().mockReturnValue({ type: 'json_schema' }),
+}));
+
+const mockConfigService = {
+  getOrThrow: jest.fn().mockReturnValue('test-api-key'),
+} as unknown as ConfigService;
+
+const mockTransactions: Transaction[] = [
+  {
+    id: '1',
+    userId: 'u1',
+    description: 'Grocery store',
+    amount: 80,
+    type: 'EXPENSE',
+    category: 'Food',
+    aiConfidence: 0.95,
+    date: '2025-01-01T00:00:00.000Z',
+    createdAt: '2025-01-01T00:00:00.000Z',
+  },
+  {
+    id: '2',
+    userId: 'u1',
+    description: 'Salary',
+    amount: 3000,
+    type: 'INCOME',
+    category: 'Income',
+    aiConfidence: null,
+    date: '2025-01-01T00:00:00.000Z',
+    createdAt: '2025-01-01T00:00:00.000Z',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AiService', () => {
+  let service: AiService;
+  let mockClient: jest.Mocked<Anthropic>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AiService,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<AiService>(AiService);
+    mockClient = (Anthropic as jest.MockedClass<typeof Anthropic>).mock
+      .instances[0] as jest.Mocked<Anthropic>;
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should initialise Anthropic client with ANTHROPIC_API_KEY', () => {
+    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
+      'ANTHROPIC_API_KEY',
+    );
+    expect(Anthropic).toHaveBeenCalledWith({ apiKey: 'test-api-key' });
+  });
+
+  // -------------------------------------------------------------------------
+  // categorizeTransaction
+  // -------------------------------------------------------------------------
+
+  describe('categorizeTransaction', () => {
+    it('should call messages.parse and return category + confidence', async () => {
+      const mockParsed = { category: 'Food', confidence: 0.92 };
+      (mockClient.messages as any) = {
+        parse: jest.fn().mockResolvedValue({ parsed_output: mockParsed }),
+      };
+
+      const result = await service.categorizeTransaction(
+        'Grocery store',
+        50,
+        'EXPENSE',
+      );
+
+      expect(mockClient.messages.parse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-opus-4-6',
+          max_tokens: 256,
+          messages: expect.arrayContaining([
+            expect.objectContaining({ role: 'user' }),
+          ]),
+        }),
+      );
+      expect(result).toEqual(mockParsed);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // generateInsights
+  // -------------------------------------------------------------------------
+
+  describe('generateInsights', () => {
+    it('should stream insights and return plain text', async () => {
+      const mockContent: Anthropic.ContentBlock[] = [
+        { type: 'text', text: 'You spend too much on food.' },
+      ];
+      const mockStream = {
+        finalMessage: jest
+          .fn()
+          .mockResolvedValue({ content: mockContent, stop_reason: 'end_turn' }),
+      };
+      (mockClient.messages as any) = {
+        stream: jest.fn().mockReturnValue(mockStream),
+      };
+
+      const result = await service.generateInsights(mockTransactions, 'weekly');
+
+      expect(mockClient.messages.stream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-opus-4-6',
+          thinking: { type: 'adaptive' },
+          messages: expect.arrayContaining([
+            expect.objectContaining({ role: 'user' }),
+          ]),
+        }),
+      );
+      expect(result).toBe('You spend too much on food.');
+    });
+
+    it('should handle empty transactions', async () => {
+      const mockStream = {
+        finalMessage: jest.fn().mockResolvedValue({
+          content: [{ type: 'text', text: 'No data available.' }],
+          stop_reason: 'end_turn',
+        }),
+      };
+      (mockClient.messages as any) = {
+        stream: jest.fn().mockReturnValue(mockStream),
+      };
+
+      const result = await service.generateInsights([], 'monthly');
+
+      const userMessage = (mockClient.messages.stream as jest.Mock).mock
+        .calls[0][0].messages[0].content as string;
+      expect(userMessage).toContain('No transactions available.');
+      expect(result).toBe('No data available.');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // generateGoalRecommendation
+  // -------------------------------------------------------------------------
+
+  describe('generateGoalRecommendation', () => {
+    it('should stream a goal recommendation', async () => {
+      const mockStream = {
+        finalMessage: jest.fn().mockResolvedValue({
+          content: [{ type: 'text', text: 'Cut dining out by 20%.' }],
+          stop_reason: 'end_turn',
+        }),
+      };
+      (mockClient.messages as any) = {
+        stream: jest.fn().mockReturnValue(mockStream),
+      };
+
+      const goal = {
+        description: 'Save for vacation',
+        targetAmount: 2000,
+        deadline: '2025-12-31',
+      };
+      const result = await service.generateGoalRecommendation(
+        goal,
+        mockTransactions,
+      );
+
+      expect(mockClient.messages.stream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-opus-4-6',
+          thinking: { type: 'adaptive' },
+        }),
+      );
+      expect(result).toBe('Cut dining out by 20%.');
+    });
+
+    it('should omit deadline line when not provided', async () => {
+      const mockStream = {
+        finalMessage: jest.fn().mockResolvedValue({
+          content: [{ type: 'text', text: 'Advice.' }],
+          stop_reason: 'end_turn',
+        }),
+      };
+      (mockClient.messages as any) = {
+        stream: jest.fn().mockReturnValue(mockStream),
+      };
+
+      await service.generateGoalRecommendation(
+        { description: 'Emergency fund', targetAmount: 1000 },
+        [],
+      );
+
+      const prompt = (mockClient.messages.stream as jest.Mock).mock.calls[0][0]
+        .messages[0].content as string;
+      expect(prompt).not.toContain('Deadline:');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // generateWeeklyChallenge
+  // -------------------------------------------------------------------------
+
+  describe('generateWeeklyChallenge', () => {
+    it('should call messages.create and return challenge text', async () => {
+      (mockClient.messages as any) = {
+        create: jest.fn().mockResolvedValue({
+          content: [
+            { type: 'text', text: 'Spend less than $60 on Food this week.' },
+          ],
+          stop_reason: 'end_turn',
+        }),
+      };
+
+      const weekStart = new Date('2025-01-06');
+      const weekEnd = new Date('2025-01-12');
+      const result = await service.generateWeeklyChallenge(
+        mockTransactions,
+        weekStart,
+        weekEnd,
+      );
+
+      expect(mockClient.messages.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-opus-4-6',
+          max_tokens: 256,
+          messages: expect.arrayContaining([
+            expect.objectContaining({ role: 'user' }),
+          ]),
+        }),
+      );
+      expect(result).toBe('Spend less than $60 on Food this week.');
+    });
+
+    it('should include date range in the prompt', async () => {
+      (mockClient.messages as any) = {
+        create: jest.fn().mockResolvedValue({
+          content: [{ type: 'text', text: 'Save at least $50.' }],
+          stop_reason: 'end_turn',
+        }),
+      };
+
+      const weekStart = new Date('2025-03-10');
+      const weekEnd = new Date('2025-03-16');
+      await service.generateWeeklyChallenge([], weekStart, weekEnd);
+
+      const prompt = (mockClient.messages.create as jest.Mock).mock.calls[0][0]
+        .messages[0].content as string;
+      expect(prompt).toContain('2025-03-10');
+      expect(prompt).toContain('2025-03-16');
+    });
+  });
+});

--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -1,6 +1,183 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import { z } from 'zod';
+import type {
+  CreateGoalDto,
+  InsightPeriod,
+  Transaction,
+  TransactionCategory,
+  TransactionType,
+} from '@financial-advisor/shared';
 
-// TODO(Issue #7): Implement categorizeTransaction, generateInsights,
-// generateGoalRecommendation, generateWeeklyChallenge using Anthropic SDK
+const TRANSACTION_CATEGORIES: [
+  TransactionCategory,
+  ...TransactionCategory[],
+] = [
+  'Food',
+  'Transport',
+  'Bills',
+  'Entertainment',
+  'Shopping',
+  'Health',
+  'Income',
+  'Other',
+];
+
+const CategorizationSchema = z.object({
+  category: z.enum(TRANSACTION_CATEGORIES),
+  confidence: z.number().min(0).max(1),
+});
+
+type Categorization = z.infer<typeof CategorizationSchema>;
+
 @Injectable()
-export class AiService {}
+export class AiService {
+  private readonly client: Anthropic;
+  private readonly model = 'claude-opus-4-6';
+
+  constructor(config: ConfigService) {
+    this.client = new Anthropic({
+      apiKey: config.getOrThrow<string>('ANTHROPIC_API_KEY'),
+    });
+  }
+
+  async categorizeTransaction(
+    description: string,
+    amount: number,
+    type: TransactionType,
+  ): Promise<Categorization> {
+    const response = await this.client.messages.parse({
+      model: this.model,
+      max_tokens: 256,
+      messages: [
+        {
+          role: 'user',
+          content: `Categorize this transaction:
+Description: ${description}
+Amount: $${amount}
+Type: ${type}
+
+Choose from: ${TRANSACTION_CATEGORIES.join(', ')}.
+Return a confidence score between 0 and 1.`,
+        },
+      ],
+      output_config: {
+        format: zodOutputFormat(CategorizationSchema, 'categorization'),
+      },
+    });
+
+    return response.parsed_output;
+  }
+
+  async generateInsights(
+    transactions: Transaction[],
+    period: InsightPeriod,
+  ): Promise<string> {
+    const stream = this.client.messages.stream({
+      model: this.model,
+      max_tokens: 1024,
+      thinking: { type: 'adaptive' },
+      messages: [
+        {
+          role: 'user',
+          content: `You are a personal finance advisor. Analyze the following ${period} transactions and provide 2-3 actionable insights in under 200 words.
+
+Transaction summary:
+${buildTransactionSummary(transactions)}`,
+        },
+      ],
+    });
+
+    const message = await stream.finalMessage();
+    return extractText(message.content);
+  }
+
+  async generateGoalRecommendation(
+    goal: CreateGoalDto,
+    transactions: Transaction[],
+  ): Promise<string> {
+    const deadlineLine = goal.deadline ? `Deadline: ${goal.deadline}` : '';
+
+    const stream = this.client.messages.stream({
+      model: this.model,
+      max_tokens: 512,
+      thinking: { type: 'adaptive' },
+      messages: [
+        {
+          role: 'user',
+          content: `You are a personal finance advisor. Given this savings goal and recent spending, provide a concrete recommendation in 2-3 sentences.
+
+Goal: ${goal.description}
+Target: $${goal.targetAmount}
+${deadlineLine}
+
+Recent spending:
+${buildTransactionSummary(transactions)}`,
+        },
+      ],
+    });
+
+    const message = await stream.finalMessage();
+    return extractText(message.content);
+  }
+
+  async generateWeeklyChallenge(
+    transactions: Transaction[],
+    weekStart: Date,
+    weekEnd: Date,
+  ): Promise<string> {
+    const from = weekStart.toISOString().split('T')[0];
+    const to = weekEnd.toISOString().split('T')[0];
+
+    const response = await this.client.messages.create({
+      model: this.model,
+      max_tokens: 256,
+      messages: [
+        {
+          role: 'user',
+          content: `You are a personal finance coach. Based on this user's recent spending, generate one specific, achievable weekly challenge for ${from} to ${to}.
+
+Recent spending:
+${buildTransactionSummary(transactions)}
+
+Return exactly one sentence starting with "Spend less than", "Save at least", or "Limit your". Use specific dollar amounts from the data.`,
+        },
+      ],
+    });
+
+    return extractText(response.content);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-private helpers
+// ---------------------------------------------------------------------------
+
+function buildTransactionSummary(transactions: Transaction[]): string {
+  if (transactions.length === 0) return 'No transactions available.';
+
+  const byCategory = transactions.reduce<
+    Record<string, { total: number; count: number }>
+  >((acc, t) => {
+    acc[t.category] ??= { total: 0, count: 0 };
+    acc[t.category].total += t.amount;
+    acc[t.category].count += 1;
+    return acc;
+  }, {});
+
+  return Object.entries(byCategory)
+    .map(
+      ([cat, { total, count }]) =>
+        `- ${cat}: $${total.toFixed(2)} (${count} tx)`,
+    )
+    .join('\n');
+}
+
+function extractText(content: Anthropic.ContentBlock[]): string {
+  return content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
         "@financial-advisor/shared": "*",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.3",
@@ -35,7 +36,8 @@
         "pg": "^8.20.0",
         "prisma": "^7.4.2",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -371,6 +373,26 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -15513,6 +15535,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -19918,6 +19953,12 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -21078,6 +21119,15 @@
       "dependencies": {
         "grammex": "^3.1.11",
         "graphmatch": "^1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {


### PR DESCRIPTION
Closes #7

## Changes
- 4 prompt methods using `claude-opus-4-6`:
  - `categorizeTransaction` — structured output via `messages.parse()` + Zod schema (category + confidence)
  - `generateInsights` — streaming with `adaptive` thinking, returns plain text summary
  - `generateGoalRecommendation` — streaming with `adaptive` thinking, 2–3 sentence advice
  - `generateWeeklyChallenge` — single API call, returns one actionable sentence
- `ANTHROPIC_API_KEY` injected via `ConfigService`
- Module-private helpers: `buildTransactionSummary` (groups by category) and `extractText` (narrows `ContentBlock[]` to text)
- 9 unit tests covering all methods and edge cases (empty transactions, missing deadline)