### PR TITLE
feat(api): implement TransactionsModule with inline AI categorization

### DIFF
--- a/apps/api/src/transactions/dto/create-transaction.dto.ts
+++ b/apps/api/src/transactions/dto/create-transaction.dto.ts
@@ -1,0 +1,14 @@
+import type {
+  TransactionCategory,
+  TransactionType,
+} from '@financial-advisor/shared';
+
+export class CreateTransactionDto {
+  description: string;
+  amount: number;
+  type: TransactionType;
+  /** Optional — AI will categorize automatically when omitted */
+  category?: TransactionCategory;
+  /** ISO-8601 — defaults to now when omitted */
+  date?: string;
+}

--- a/apps/api/src/transactions/dto/get-transactions-query.dto.ts
+++ b/apps/api/src/transactions/dto/get-transactions-query.dto.ts
@@ -1,0 +1,13 @@
+import type {
+  TransactionCategory,
+  TransactionType,
+} from '@financial-advisor/shared';
+
+export class GetTransactionsQueryDto {
+  type?: TransactionType;
+  category?: TransactionCategory;
+  from?: string;
+  to?: string;
+  page?: number;
+  limit?: number;
+}

--- a/apps/api/src/transactions/transactions.controller.spec.ts
+++ b/apps/api/src/transactions/transactions.controller.spec.ts
@@ -1,0 +1,111 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TransactionsController } from './transactions.controller';
+import { TransactionsService } from './transactions.service';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockTransaction = {
+  id: 'tx-1',
+  userId: 'user-1',
+  description: 'Coffee',
+  amount: 5,
+  type: 'EXPENSE',
+  category: 'Food',
+  aiConfidence: 0.9,
+  date: new Date('2025-01-01'),
+  createdAt: new Date('2025-01-01'),
+};
+
+const mockService = {
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+};
+
+const mockRequest = { user: { id: 'user-1', email: 'user@test.com' } };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TransactionsController', () => {
+  let controller: TransactionsController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TransactionsController],
+      providers: [{ provide: TransactionsService, useValue: mockService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<TransactionsController>(TransactionsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /transactions
+  // -------------------------------------------------------------------------
+
+  describe('create', () => {
+    it('should call service.create with userId and dto', async () => {
+      mockService.create.mockResolvedValue(mockTransaction);
+
+      const dto = { description: 'Coffee', amount: 5, type: 'EXPENSE' as const };
+      const result = await controller.create(mockRequest as any, dto);
+
+      expect(mockService.create).toHaveBeenCalledWith('user-1', dto);
+      expect(result).toEqual(mockTransaction);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /transactions
+  // -------------------------------------------------------------------------
+
+  describe('findAll', () => {
+    it('should call service.findAll with userId and query', async () => {
+      const paginated = { data: [mockTransaction], total: 1, page: 1, limit: 20 };
+      mockService.findAll.mockResolvedValue(paginated);
+
+      const query = { type: 'EXPENSE' as const };
+      const result = await controller.findAll(mockRequest as any, query);
+
+      expect(mockService.findAll).toHaveBeenCalledWith('user-1', query);
+      expect(result).toEqual(paginated);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /transactions/:id
+  // -------------------------------------------------------------------------
+
+  describe('findOne', () => {
+    it('should call service.findOne with userId and id', async () => {
+      mockService.findOne.mockResolvedValue(mockTransaction);
+
+      const result = await controller.findOne(mockRequest as any, 'tx-1');
+
+      expect(mockService.findOne).toHaveBeenCalledWith('user-1', 'tx-1');
+      expect(result).toEqual(mockTransaction);
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      mockService.findOne.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.findOne(mockRequest as any, 'bad-id'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/transactions/transactions.controller.ts
+++ b/apps/api/src/transactions/transactions.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
+import { GetTransactionsQueryDto } from './dto/get-transactions-query.dto';
+import { TransactionsService } from './transactions.service';
+
+interface AuthRequest {
+  user: { id: string; email: string };
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller('transactions')
+export class TransactionsController {
+  constructor(private readonly transactions: TransactionsService) {}
+
+  @Post()
+  create(@Request() req: AuthRequest, @Body() dto: CreateTransactionDto) {
+    return this.transactions.create(req.user.id, dto);
+  }
+
+  @Get()
+  findAll(
+    @Request() req: AuthRequest,
+    @Query() query: GetTransactionsQueryDto,
+  ) {
+    return this.transactions.findAll(req.user.id, query);
+  }
+
+  @Get(':id')
+  findOne(@Request() req: AuthRequest, @Param('id') id: string) {
+    return this.transactions.findOne(req.user.id, id);
+  }
+}

--- a/apps/api/src/transactions/transactions.module.ts
+++ b/apps/api/src/transactions/transactions.module.ts
@@ -1,5 +1,12 @@
 import { Module } from '@nestjs/common';
+import { AiModule } from '../ai/ai.module';
+import { TransactionsController } from './transactions.controller';
+import { TransactionsService } from './transactions.service';
 
-// TODO(Issue #8): TransactionsController + TransactionsService with inline AI categorization
-@Module({})
+@Module({
+  imports: [AiModule],
+  controllers: [TransactionsController],
+  providers: [TransactionsService],
+  exports: [TransactionsService],
+})
 export class TransactionsModule {}

--- a/apps/api/src/transactions/transactions.service.spec.ts
+++ b/apps/api/src/transactions/transactions.service.spec.ts
@@ -1,0 +1,204 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiService } from '../ai/ai.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { TransactionsService } from './transactions.service';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockTransaction = {
+  id: 'tx-1',
+  userId: 'user-1',
+  description: 'Coffee',
+  amount: 5,
+  type: 'EXPENSE',
+  category: 'Food',
+  aiConfidence: 0.9,
+  date: new Date('2025-01-01'),
+  createdAt: new Date('2025-01-01'),
+};
+
+const mockPrisma = {
+  transaction: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+    findFirst: jest.fn(),
+  },
+  $transaction: jest.fn(),
+};
+
+const mockAi = {
+  categorizeTransaction: jest.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TransactionsService', () => {
+  let service: TransactionsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TransactionsService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: AiService, useValue: mockAi },
+      ],
+    }).compile();
+
+    service = module.get<TransactionsService>(TransactionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // create
+  // -------------------------------------------------------------------------
+
+  describe('create', () => {
+    it('should auto-categorize when category is omitted', async () => {
+      mockAi.categorizeTransaction.mockResolvedValue({
+        category: 'Food',
+        confidence: 0.9,
+      });
+      mockPrisma.transaction.create.mockResolvedValue(mockTransaction);
+
+      const result = await service.create('user-1', {
+        description: 'Coffee',
+        amount: 5,
+        type: 'EXPENSE',
+      });
+
+      expect(mockAi.categorizeTransaction).toHaveBeenCalledWith(
+        'Coffee',
+        5,
+        'EXPENSE',
+      );
+      expect(mockPrisma.transaction.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          category: 'Food',
+          aiConfidence: 0.9,
+        }),
+      });
+      expect(result).toEqual(mockTransaction);
+    });
+
+    it('should skip AI when category is provided', async () => {
+      mockPrisma.transaction.create.mockResolvedValue({
+        ...mockTransaction,
+        aiConfidence: null,
+      });
+
+      await service.create('user-1', {
+        description: 'Salary',
+        amount: 3000,
+        type: 'INCOME',
+        category: 'Income',
+      });
+
+      expect(mockAi.categorizeTransaction).not.toHaveBeenCalled();
+      expect(mockPrisma.transaction.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ category: 'Income', aiConfidence: null }),
+      });
+    });
+
+    it('should use provided date when given', async () => {
+      mockPrisma.transaction.create.mockResolvedValue(mockTransaction);
+      mockAi.categorizeTransaction.mockResolvedValue({
+        category: 'Food',
+        confidence: 0.8,
+      });
+
+      await service.create('user-1', {
+        description: 'Lunch',
+        amount: 12,
+        type: 'EXPENSE',
+        date: '2025-06-15T12:00:00.000Z',
+      });
+
+      const createdData = mockPrisma.transaction.create.mock.calls[0][0].data;
+      expect(createdData.date).toEqual(new Date('2025-06-15T12:00:00.000Z'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // findAll
+  // -------------------------------------------------------------------------
+
+  describe('findAll', () => {
+    beforeEach(() => {
+      mockPrisma.$transaction.mockResolvedValue([[mockTransaction], 1]);
+    });
+
+    it('should return paginated transactions with defaults', async () => {
+      const result = await service.findAll('user-1', {});
+
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+      expect(result).toEqual({
+        data: [mockTransaction],
+        total: 1,
+        page: 1,
+        limit: 20,
+      });
+    });
+
+    it('should apply type and category filters', async () => {
+      const result = await service.findAll('user-1', {
+        type: 'EXPENSE',
+        category: 'Food',
+      });
+
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(result.data).toHaveLength(1);
+    });
+
+    it('should apply date range filter', async () => {
+      const result = await service.findAll('user-1', {
+        from: '2025-01-01',
+        to: '2025-01-31',
+      });
+
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(result.total).toBe(1);
+    });
+
+    it('should cap limit at 100', async () => {
+      const result = await service.findAll('user-1', { limit: 999 });
+
+      expect(result.limit).toBe(100);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // findOne
+  // -------------------------------------------------------------------------
+
+  describe('findOne', () => {
+    it('should return a transaction belonging to the user', async () => {
+      mockPrisma.transaction.findFirst.mockResolvedValue(mockTransaction);
+
+      const result = await service.findOne('user-1', 'tx-1');
+
+      expect(mockPrisma.transaction.findFirst).toHaveBeenCalledWith({
+        where: { id: 'tx-1', userId: 'user-1' },
+      });
+      expect(result).toEqual(mockTransaction);
+    });
+
+    it('should throw NotFoundException when transaction is not found', async () => {
+      mockPrisma.transaction.findFirst.mockResolvedValue(null);
+
+      await expect(service.findOne('user-1', 'bad-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Transaction } from '@prisma/client';
+import type { PaginatedTransactions } from '@financial-advisor/shared';
+import { AiService } from '../ai/ai.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
+import { GetTransactionsQueryDto } from './dto/get-transactions-query.dto';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+
+@Injectable()
+export class TransactionsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly ai: AiService,
+  ) {}
+
+  async create(userId: string, dto: CreateTransactionDto): Promise<Transaction> {
+    let category = dto.category;
+    let aiConfidence: number | null = null;
+
+    if (!category) {
+      const result = await this.ai.categorizeTransaction(
+        dto.description,
+        dto.amount,
+        dto.type,
+      );
+      category = result.category;
+      aiConfidence = result.confidence;
+    }
+
+    return this.prisma.transaction.create({
+      data: {
+        userId,
+        description: dto.description,
+        amount: dto.amount,
+        type: dto.type,
+        category,
+        aiConfidence,
+        date: dto.date ? new Date(dto.date) : new Date(),
+      },
+    });
+  }
+
+  async findAll(
+    userId: string,
+    query: GetTransactionsQueryDto,
+  ): Promise<PaginatedTransactions> {
+    const page = Math.max(1, query.page ?? DEFAULT_PAGE);
+    const limit = Math.min(100, Math.max(1, query.limit ?? DEFAULT_LIMIT));
+    const skip = (page - 1) * limit;
+
+    const where = buildWhereClause(userId, query);
+
+    const [data, total] = await this.prisma.$transaction([
+      this.prisma.transaction.findMany({
+        where,
+        orderBy: { date: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.transaction.count({ where }),
+    ]);
+
+    return { data: data as any, total, page, limit };
+  }
+
+  async findOne(userId: string, id: string): Promise<Transaction> {
+    const transaction = await this.prisma.transaction.findFirst({
+      where: { id, userId },
+    });
+
+    if (!transaction) throw new NotFoundException('Transaction not found');
+    return transaction;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-private helper
+// ---------------------------------------------------------------------------
+
+function buildWhereClause(
+  userId: string,
+  query: GetTransactionsQueryDto,
+): object {
+  const where: Record<string, unknown> = { userId };
+
+  if (query.type) where['type'] = query.type;
+  if (query.category) where['category'] = query.category;
+  if (query.from ?? query.to) {
+    where['date'] = {
+      ...(query.from ? { gte: new Date(query.from) } : {}),
+      ...(query.to ? { lte: new Date(query.to) } : {}),
+    };
+  }
+
+  return where;
+}


### PR DESCRIPTION
Closes #8

## Changes
- `TransactionsService` — `create`, `findAll` (paginated + filtered), `findOne`
- `create` calls `AiService.categorizeTransaction` automatically when no category is provided; skips AI when user supplies one
- `findAll` supports filtering by `type`, `category`, date range (`from`/`to`), and pagination (`page`/`limit`, capped at 100)
- `TransactionsController` — `POST /transactions`, `GET /transactions`, `GET /transactions/:id` all protected by `JwtAuthGuard`
- 15 unit tests across service (10) and controller (5)