### PR TITLE
feat(api): implement InsightsModule with AI text generation

### DIFF
--- a/apps/api/src/insights/insights.controller.spec.ts
+++ b/apps/api/src/insights/insights.controller.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { InsightsController } from './insights.controller';
+import { InsightsService } from './insights.service';
+
+const mockInsight = {
+  period: 'weekly',
+  summary: 'You spend a lot on food.',
+  from: '2025-01-01T00:00:00.000Z',
+  to: '2025-01-07T00:00:00.000Z',
+  generatedAt: '2025-01-07T12:00:00.000Z',
+};
+
+const mockService = { generate: jest.fn() };
+const mockRequest = { user: { id: 'user-1' } };
+
+describe('InsightsController', () => {
+  let controller: InsightsController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InsightsController],
+      providers: [{ provide: InsightsService, useValue: mockService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<InsightsController>(InsightsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should call service.generate with userId and period', async () => {
+    mockService.generate.mockResolvedValue(mockInsight);
+
+    const result = await controller.generate(mockRequest as any, 'weekly');
+
+    expect(mockService.generate).toHaveBeenCalledWith('user-1', 'weekly');
+    expect(result).toEqual(mockInsight);
+  });
+
+  it('should default to weekly when period is not provided', async () => {
+    mockService.generate.mockResolvedValue(mockInsight);
+
+    await controller.generate(mockRequest as any, undefined as any);
+
+    expect(mockService.generate).toHaveBeenCalledWith('user-1', 'weekly');
+  });
+
+  it('should pass monthly period to the service', async () => {
+    mockService.generate.mockResolvedValue({ ...mockInsight, period: 'monthly' });
+
+    await controller.generate(mockRequest as any, 'monthly');
+
+    expect(mockService.generate).toHaveBeenCalledWith('user-1', 'monthly');
+  });
+});

--- a/apps/api/src/insights/insights.controller.ts
+++ b/apps/api/src/insights/insights.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Query, Request, UseGuards } from '@nestjs/common';
+import type { InsightPeriod } from '@financial-advisor/shared';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { InsightsService } from './insights.service';
+
+interface AuthRequest {
+  user: { id: string };
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller('insights')
+export class InsightsController {
+  constructor(private readonly insights: InsightsService) {}
+
+  @Get()
+  generate(
+    @Request() req: AuthRequest,
+    @Query('period') period: InsightPeriod = 'weekly',
+  ) {
+    return this.insights.generate(req.user.id, period);
+  }
+}

--- a/apps/api/src/insights/insights.module.ts
+++ b/apps/api/src/insights/insights.module.ts
@@ -1,5 +1,11 @@
 import { Module } from '@nestjs/common';
+import { AiModule } from '../ai/ai.module';
+import { InsightsController } from './insights.controller';
+import { InsightsService } from './insights.service';
 
-// TODO(Issue #9): InsightsController + InsightsService with AI text generation
-@Module({})
+@Module({
+  imports: [AiModule],
+  controllers: [InsightsController],
+  providers: [InsightsService],
+})
 export class InsightsModule {}

--- a/apps/api/src/insights/insights.service.spec.ts
+++ b/apps/api/src/insights/insights.service.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiService } from '../ai/ai.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { InsightsService } from './insights.service';
+
+const mockTransactions = [
+  {
+    id: 'tx-1',
+    userId: 'u1',
+    description: 'Groceries',
+    amount: 80,
+    type: 'EXPENSE',
+    category: 'Food',
+    aiConfidence: 0.9,
+    date: new Date(),
+    createdAt: new Date(),
+  },
+];
+
+const mockPrisma = {
+  transaction: { findMany: jest.fn() },
+};
+
+const mockAi = {
+  generateInsights: jest.fn(),
+};
+
+describe('InsightsService', () => {
+  let service: InsightsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InsightsService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: AiService, useValue: mockAi },
+      ],
+    }).compile();
+
+    service = module.get<InsightsService>(InsightsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should return an Insight with correct shape for weekly period', async () => {
+    mockPrisma.transaction.findMany.mockResolvedValue(mockTransactions);
+    mockAi.generateInsights.mockResolvedValue('You spend a lot on food.');
+
+    const result = await service.generate('u1', 'weekly');
+
+    expect(result.period).toBe('weekly');
+    expect(result.summary).toBe('You spend a lot on food.');
+    expect(result.from).toBeDefined();
+    expect(result.to).toBeDefined();
+    expect(result.generatedAt).toBeDefined();
+  });
+
+  it('should return an Insight for monthly period', async () => {
+    mockPrisma.transaction.findMany.mockResolvedValue([]);
+    mockAi.generateInsights.mockResolvedValue('No spending this month.');
+
+    const result = await service.generate('u1', 'monthly');
+
+    expect(result.period).toBe('monthly');
+    expect(result.summary).toBe('No spending this month.');
+  });
+
+  it('should query transactions within the correct date range', async () => {
+    mockPrisma.transaction.findMany.mockResolvedValue([]);
+    mockAi.generateInsights.mockResolvedValue('OK');
+
+    const before = new Date();
+    await service.generate('u1', 'weekly');
+    const after = new Date();
+
+    const { where } = mockPrisma.transaction.findMany.mock.calls[0][0];
+    expect(where.userId).toBe('u1');
+
+    const from = new Date(where.date.gte);
+    const to = new Date(where.date.lte);
+    const diffDays = (to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24);
+    expect(diffDays).toBeCloseTo(7, 0);
+    expect(to.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(to.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  it('should pass transactions and period to AiService', async () => {
+    mockPrisma.transaction.findMany.mockResolvedValue(mockTransactions);
+    mockAi.generateInsights.mockResolvedValue('Insight text');
+
+    await service.generate('u1', 'weekly');
+
+    expect(mockAi.generateInsights).toHaveBeenCalledWith(
+      mockTransactions,
+      'weekly',
+    );
+  });
+});

--- a/apps/api/src/insights/insights.service.ts
+++ b/apps/api/src/insights/insights.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import type { Insight, InsightPeriod } from '@financial-advisor/shared';
+import { AiService } from '../ai/ai.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class InsightsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly ai: AiService,
+  ) {}
+
+  async generate(userId: string, period: InsightPeriod): Promise<Insight> {
+    const { from, to } = getDateRange(period);
+
+    const transactions = await this.prisma.transaction.findMany({
+      where: { userId, date: { gte: from, lte: to } },
+      orderBy: { date: 'desc' },
+    });
+
+    const summary = await this.ai.generateInsights(transactions as any, period);
+
+    return {
+      period,
+      summary,
+      from: from.toISOString(),
+      to: to.toISOString(),
+      generatedAt: new Date().toISOString(),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-private helper
+// ---------------------------------------------------------------------------
+
+function getDateRange(period: InsightPeriod): { from: Date; to: Date } {
+  const to = new Date();
+  const from = new Date(to);
+
+  if (period === 'weekly') {
+    from.setDate(from.getDate() - 7);
+  } else {
+    from.setMonth(from.getMonth() - 1);
+  }
+
+  return { from, to };
+}


### PR DESCRIPTION
Closes #9

## Changes
- `InsightsService.generate(userId, period)` — queries the last 7 days (weekly) or 30 days (monthly) of transactions, passes them to `AiService.generateInsights`, returns an `Insight` object
- `InsightsController` — `GET /insights?period=weekly|monthly`, protected by `JwtAuthGuard`, defaults to `weekly`
- 9 unit tests across service (5) and controller (4)