### PR TITLE
feat(api): implement GoalsModule with AI recommendation

### DIFF
--- a/apps/api/src/goals/dto/create-goal.dto.ts
+++ b/apps/api/src/goals/dto/create-goal.dto.ts
@@ -1,0 +1,6 @@
+export class CreateGoalDto {
+  description: string;
+  targetAmount: number;
+  /** ISO-8601 optional target date */
+  deadline?: string;
+}

--- a/apps/api/src/goals/goals.controller.spec.ts
+++ b/apps/api/src/goals/goals.controller.spec.ts
@@ -1,0 +1,83 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GoalsController } from './goals.controller';
+import { GoalsService } from './goals.service';
+
+const mockGoal = {
+  id: 'goal-1',
+  userId: 'user-1',
+  description: 'Save for vacation',
+  targetAmount: 2000,
+  deadline: null,
+  aiRecommendation: 'Cut dining out.',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockService = { create: jest.fn(), findAll: jest.fn(), findOne: jest.fn() };
+const mockRequest = { user: { id: 'user-1' } };
+
+describe('GoalsController', () => {
+  let controller: GoalsController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GoalsController],
+      providers: [{ provide: GoalsService, useValue: mockService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<GoalsController>(GoalsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('POST /goals', () => {
+    it('should create a goal', async () => {
+      mockService.create.mockResolvedValue(mockGoal);
+      const dto = { description: 'Save for vacation', targetAmount: 2000 };
+
+      const result = await controller.create(mockRequest as any, dto);
+
+      expect(mockService.create).toHaveBeenCalledWith('user-1', dto);
+      expect(result).toEqual(mockGoal);
+    });
+  });
+
+  describe('GET /goals', () => {
+    it('should return all goals for the user', async () => {
+      mockService.findAll.mockResolvedValue([mockGoal]);
+
+      const result = await controller.findAll(mockRequest as any);
+
+      expect(mockService.findAll).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual([mockGoal]);
+    });
+  });
+
+  describe('GET /goals/:id', () => {
+    it('should return one goal', async () => {
+      mockService.findOne.mockResolvedValue(mockGoal);
+
+      const result = await controller.findOne(mockRequest as any, 'goal-1');
+
+      expect(mockService.findOne).toHaveBeenCalledWith('user-1', 'goal-1');
+      expect(result).toEqual(mockGoal);
+    });
+
+    it('should propagate NotFoundException', async () => {
+      mockService.findOne.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.findOne(mockRequest as any, 'bad-id'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/goals/goals.controller.ts
+++ b/apps/api/src/goals/goals.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CreateGoalDto } from './dto/create-goal.dto';
+import { GoalsService } from './goals.service';
+
+interface AuthRequest {
+  user: { id: string };
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller('goals')
+export class GoalsController {
+  constructor(private readonly goals: GoalsService) {}
+
+  @Post()
+  create(@Request() req: AuthRequest, @Body() dto: CreateGoalDto) {
+    return this.goals.create(req.user.id, dto);
+  }
+
+  @Get()
+  findAll(@Request() req: AuthRequest) {
+    return this.goals.findAll(req.user.id);
+  }
+
+  @Get(':id')
+  findOne(@Request() req: AuthRequest, @Param('id') id: string) {
+    return this.goals.findOne(req.user.id, id);
+  }
+}

--- a/apps/api/src/goals/goals.module.ts
+++ b/apps/api/src/goals/goals.module.ts
@@ -1,5 +1,11 @@
 import { Module } from '@nestjs/common';
+import { AiModule } from '../ai/ai.module';
+import { GoalsController } from './goals.controller';
+import { GoalsService } from './goals.service';
 
-// TODO(Issue #10): GoalsController + GoalsService with AI recommendation generation
-@Module({})
+@Module({
+  imports: [AiModule],
+  controllers: [GoalsController],
+  providers: [GoalsService],
+})
 export class GoalsModule {}

--- a/apps/api/src/goals/goals.service.spec.ts
+++ b/apps/api/src/goals/goals.service.spec.ts
@@ -1,0 +1,125 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiService } from '../ai/ai.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { GoalsService } from './goals.service';
+
+const mockGoal = {
+  id: 'goal-1',
+  userId: 'user-1',
+  description: 'Save for vacation',
+  targetAmount: 2000,
+  deadline: new Date('2025-12-31'),
+  aiRecommendation: 'Cut dining out.',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockPrisma = {
+  transaction: { findMany: jest.fn() },
+  goal: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+  },
+};
+
+const mockAi = { generateGoalRecommendation: jest.fn() };
+
+describe('GoalsService', () => {
+  let service: GoalsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GoalsService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: AiService, useValue: mockAi },
+      ],
+    }).compile();
+
+    service = module.get<GoalsService>(GoalsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should fetch recent transactions, call AI, and persist goal', async () => {
+      mockPrisma.transaction.findMany.mockResolvedValue([]);
+      mockAi.generateGoalRecommendation.mockResolvedValue('Cut dining out.');
+      mockPrisma.goal.create.mockResolvedValue(mockGoal);
+
+      const result = await service.create('user-1', {
+        description: 'Save for vacation',
+        targetAmount: 2000,
+        deadline: '2025-12-31',
+      });
+
+      expect(mockPrisma.transaction.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 'user-1' }, take: 50 }),
+      );
+      expect(mockAi.generateGoalRecommendation).toHaveBeenCalled();
+      expect(mockPrisma.goal.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          aiRecommendation: 'Cut dining out.',
+          deadline: new Date('2025-12-31'),
+        }),
+      });
+      expect(result).toEqual(mockGoal);
+    });
+
+    it('should set deadline to null when not provided', async () => {
+      mockPrisma.transaction.findMany.mockResolvedValue([]);
+      mockAi.generateGoalRecommendation.mockResolvedValue('Save more.');
+      mockPrisma.goal.create.mockResolvedValue({ ...mockGoal, deadline: null });
+
+      await service.create('user-1', {
+        description: 'Emergency fund',
+        targetAmount: 1000,
+      });
+
+      expect(mockPrisma.goal.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ deadline: null }),
+      });
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all goals for the user', async () => {
+      mockPrisma.goal.findMany.mockResolvedValue([mockGoal]);
+
+      const result = await service.findAll('user-1');
+
+      expect(mockPrisma.goal.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result).toEqual([mockGoal]);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return the goal when found', async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue(mockGoal);
+
+      const result = await service.findOne('user-1', 'goal-1');
+
+      expect(mockPrisma.goal.findFirst).toHaveBeenCalledWith({
+        where: { id: 'goal-1', userId: 'user-1' },
+      });
+      expect(result).toEqual(mockGoal);
+    });
+
+    it('should throw NotFoundException when goal not found', async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue(null);
+
+      await expect(service.findOne('user-1', 'bad-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/apps/api/src/goals/goals.service.ts
+++ b/apps/api/src/goals/goals.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Goal } from '@prisma/client';
+import { AiService } from '../ai/ai.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateGoalDto } from './dto/create-goal.dto';
+
+@Injectable()
+export class GoalsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly ai: AiService,
+  ) {}
+
+  async create(userId: string, dto: CreateGoalDto): Promise<Goal> {
+    const recentTransactions = await this.prisma.transaction.findMany({
+      where: { userId },
+      orderBy: { date: 'desc' },
+      take: 50,
+    });
+
+    const aiRecommendation = await this.ai.generateGoalRecommendation(
+      dto,
+      recentTransactions as any,
+    );
+
+    return this.prisma.goal.create({
+      data: {
+        userId,
+        description: dto.description,
+        targetAmount: dto.targetAmount,
+        deadline: dto.deadline ? new Date(dto.deadline) : null,
+        aiRecommendation,
+      },
+    });
+  }
+
+  async findAll(userId: string): Promise<Goal[]> {
+    return this.prisma.goal.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findOne(userId: string, id: string): Promise<Goal> {
+    const goal = await this.prisma.goal.findFirst({ where: { id, userId } });
+    if (!goal) throw new NotFoundException('Goal not found');
+    return goal;
+  }
+}


### PR DESCRIPTION
Closes #10

## Changes
- `GoalsService` — `create` fetches last 50 transactions, calls `AiService.generateGoalRecommendation`, persists goal with cached recommendation; `findAll` returns user goals ordered by creation date; `findOne` scoped to authenticated user
- `GoalsController` — `POST /goals`, `GET /goals`, `GET /goals/:id` all behind `JwtAuthGuard`
- 11 unit tests across service (7) and controller (4), all passing

## Commits
- `feat(goals): add CreateGoalDto`
- `feat(goals): add GoalsService with AI recommendation on create`
- `feat(goals): add GoalsController and wire GoalsModule`
- `test(goals): add unit tests for GoalsService and GoalsController`