### PR TITLE
feat(api): implement ChallengesModule with AI weekly challenge generation

### DIFF
--- a/apps/api/src/challenges/challenges.controller.spec.ts
+++ b/apps/api/src/challenges/challenges.controller.spec.ts
@@ -1,0 +1,104 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ChallengesController } from './challenges.controller';
+import { ChallengesService } from './challenges.service';
+
+const mockChallenge = {
+  id: 'ch-1',
+  userId: 'user-1',
+  description: 'Spend less than $50 on Food this week.',
+  weekStart: new Date('2025-01-06'),
+  weekEnd: new Date('2025-01-12'),
+  status: 'ACTIVE',
+  createdAt: new Date(),
+};
+
+const mockService = {
+  generate: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  updateStatus: jest.fn(),
+};
+const mockRequest = { user: { id: 'user-1' } };
+
+describe('ChallengesController', () => {
+  let controller: ChallengesController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChallengesController],
+      providers: [{ provide: ChallengesService, useValue: mockService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<ChallengesController>(ChallengesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('POST /challenges/generate', () => {
+    it('should call service.generate with userId', async () => {
+      mockService.generate.mockResolvedValue(mockChallenge);
+
+      const result = await controller.generate(mockRequest as any);
+
+      expect(mockService.generate).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual(mockChallenge);
+    });
+  });
+
+  describe('GET /challenges', () => {
+    it('should return all challenges for the user', async () => {
+      mockService.findAll.mockResolvedValue([mockChallenge]);
+
+      const result = await controller.findAll(mockRequest as any);
+
+      expect(mockService.findAll).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual([mockChallenge]);
+    });
+  });
+
+  describe('GET /challenges/:id', () => {
+    it('should return one challenge', async () => {
+      mockService.findOne.mockResolvedValue(mockChallenge);
+
+      const result = await controller.findOne(mockRequest as any, 'ch-1');
+
+      expect(mockService.findOne).toHaveBeenCalledWith('user-1', 'ch-1');
+      expect(result).toEqual(mockChallenge);
+    });
+
+    it('should propagate NotFoundException', async () => {
+      mockService.findOne.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.findOne(mockRequest as any, 'bad-id'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('PATCH /challenges/:id/status', () => {
+    it('should update the challenge status', async () => {
+      const updated = { ...mockChallenge, status: 'COMPLETED' };
+      mockService.updateStatus.mockResolvedValue(updated);
+
+      const result = await controller.updateStatus(mockRequest as any, 'ch-1', {
+        status: 'COMPLETED',
+      });
+
+      expect(mockService.updateStatus).toHaveBeenCalledWith(
+        'user-1',
+        'ch-1',
+        'COMPLETED',
+      );
+      expect(result).toEqual(updated);
+    });
+  });
+});

--- a/apps/api/src/challenges/challenges.controller.ts
+++ b/apps/api/src/challenges/challenges.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ChallengesService } from './challenges.service';
+import { UpdateChallengeStatusDto } from './dto/update-challenge-status.dto';
+
+interface AuthRequest {
+  user: { id: string };
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller('challenges')
+export class ChallengesController {
+  constructor(private readonly challenges: ChallengesService) {}
+
+  @Post('generate')
+  generate(@Request() req: AuthRequest) {
+    return this.challenges.generate(req.user.id);
+  }
+
+  @Get()
+  findAll(@Request() req: AuthRequest) {
+    return this.challenges.findAll(req.user.id);
+  }
+
+  @Get(':id')
+  findOne(@Request() req: AuthRequest, @Param('id') id: string) {
+    return this.challenges.findOne(req.user.id, id);
+  }
+
+  @Patch(':id/status')
+  updateStatus(
+    @Request() req: AuthRequest,
+    @Param('id') id: string,
+    @Body() dto: UpdateChallengeStatusDto,
+  ) {
+    return this.challenges.updateStatus(req.user.id, id, dto.status);
+  }
+}

--- a/apps/api/src/challenges/challenges.module.ts
+++ b/apps/api/src/challenges/challenges.module.ts
@@ -1,5 +1,11 @@
 import { Module } from '@nestjs/common';
+import { AiModule } from '../ai/ai.module';
+import { ChallengesController } from './challenges.controller';
+import { ChallengesService } from './challenges.service';
 
-// TODO(Issue #11): ChallengesController + ChallengesService with AI challenge generation
-@Module({})
+@Module({
+  imports: [AiModule],
+  controllers: [ChallengesController],
+  providers: [ChallengesService],
+})
 export class ChallengesModule {}

--- a/apps/api/src/challenges/challenges.service.spec.ts
+++ b/apps/api/src/challenges/challenges.service.spec.ts
@@ -1,0 +1,157 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiService } from '../ai/ai.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { ChallengesService } from './challenges.service';
+
+const mockChallenge = {
+  id: 'ch-1',
+  userId: 'user-1',
+  description: 'Spend less than $50 on Food this week.',
+  weekStart: new Date('2025-01-06'),
+  weekEnd: new Date('2025-01-12'),
+  status: 'ACTIVE',
+  createdAt: new Date(),
+};
+
+const mockPrisma = {
+  transaction: { findMany: jest.fn() },
+  challenge: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+const mockAi = { generateWeeklyChallenge: jest.fn() };
+
+describe('ChallengesService', () => {
+  let service: ChallengesService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChallengesService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: AiService, useValue: mockAi },
+      ],
+    }).compile();
+
+    service = module.get<ChallengesService>(ChallengesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('generate', () => {
+    it('should fetch transactions, call AI, and persist challenge', async () => {
+      mockPrisma.transaction.findMany.mockResolvedValue([]);
+      mockAi.generateWeeklyChallenge.mockResolvedValue(
+        'Spend less than $50 on Food this week.',
+      );
+      mockPrisma.challenge.create.mockResolvedValue(mockChallenge);
+
+      const result = await service.generate('user-1');
+
+      expect(mockPrisma.transaction.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 'user-1' }, take: 50 }),
+      );
+      expect(mockAi.generateWeeklyChallenge).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.any(Date),
+        expect.any(Date),
+      );
+      expect(mockPrisma.challenge.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          userId: 'user-1',
+          description: 'Spend less than $50 on Food this week.',
+        }),
+      });
+      expect(result).toEqual(mockChallenge);
+    });
+
+    it('should compute weekStart as Sunday and weekEnd as Saturday', async () => {
+      mockPrisma.transaction.findMany.mockResolvedValue([]);
+      mockAi.generateWeeklyChallenge.mockResolvedValue('Challenge text');
+      mockPrisma.challenge.create.mockResolvedValue(mockChallenge);
+
+      await service.generate('user-1');
+
+      const { weekStart, weekEnd } =
+        mockPrisma.challenge.create.mock.calls[0][0].data;
+
+      expect(weekStart.getDay()).toBe(0); // Sunday
+      expect(weekEnd.getDay()).toBe(6); // Saturday
+      const diffDays =
+        (weekEnd.getTime() - weekStart.getTime()) / (1000 * 60 * 60 * 24);
+      // weekStart is 00:00:00, weekEnd is 23:59:59.999 — diff is ~6.999 days
+      expect(diffDays).toBeGreaterThanOrEqual(6);
+      expect(diffDays).toBeLessThan(7);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return challenges for the user ordered by weekStart desc', async () => {
+      mockPrisma.challenge.findMany.mockResolvedValue([mockChallenge]);
+
+      const result = await service.findAll('user-1');
+
+      expect(mockPrisma.challenge.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        orderBy: { weekStart: 'desc' },
+      });
+      expect(result).toEqual([mockChallenge]);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a challenge scoped to the user', async () => {
+      mockPrisma.challenge.findFirst.mockResolvedValue(mockChallenge);
+
+      const result = await service.findOne('user-1', 'ch-1');
+
+      expect(mockPrisma.challenge.findFirst).toHaveBeenCalledWith({
+        where: { id: 'ch-1', userId: 'user-1' },
+      });
+      expect(result).toEqual(mockChallenge);
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      mockPrisma.challenge.findFirst.mockResolvedValue(null);
+
+      await expect(service.findOne('user-1', 'bad-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should update and return the challenge', async () => {
+      mockPrisma.challenge.findFirst.mockResolvedValue(mockChallenge);
+      mockPrisma.challenge.update.mockResolvedValue({
+        ...mockChallenge,
+        status: 'COMPLETED',
+      });
+
+      const result = await service.updateStatus('user-1', 'ch-1', 'COMPLETED');
+
+      expect(mockPrisma.challenge.update).toHaveBeenCalledWith({
+        where: { id: 'ch-1' },
+        data: { status: 'COMPLETED' },
+      });
+      expect(result.status).toBe('COMPLETED');
+    });
+
+    it('should throw NotFoundException when challenge does not belong to user', async () => {
+      mockPrisma.challenge.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.updateStatus('user-1', 'bad-id', 'FAILED'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/challenges/challenges.service.ts
+++ b/apps/api/src/challenges/challenges.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Challenge } from '@prisma/client';
+import type { ChallengeStatus } from '@financial-advisor/shared';
+import { AiService } from '../ai/ai.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class ChallengesService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly ai: AiService,
+  ) {}
+
+  async generate(userId: string): Promise<Challenge> {
+    const { weekStart, weekEnd } = getCurrentWeek();
+
+    const recentTransactions = await this.prisma.transaction.findMany({
+      where: { userId },
+      orderBy: { date: 'desc' },
+      take: 50,
+    });
+
+    const description = await this.ai.generateWeeklyChallenge(
+      recentTransactions as any,
+      weekStart,
+      weekEnd,
+    );
+
+    return this.prisma.challenge.create({
+      data: { userId, description, weekStart, weekEnd },
+    });
+  }
+
+  async findAll(userId: string): Promise<Challenge[]> {
+    return this.prisma.challenge.findMany({
+      where: { userId },
+      orderBy: { weekStart: 'desc' },
+    });
+  }
+
+  async findOne(userId: string, id: string): Promise<Challenge> {
+    const challenge = await this.prisma.challenge.findFirst({
+      where: { id, userId },
+    });
+    if (!challenge) throw new NotFoundException('Challenge not found');
+    return challenge;
+  }
+
+  async updateStatus(
+    userId: string,
+    id: string,
+    status: ChallengeStatus,
+  ): Promise<Challenge> {
+    await this.findOne(userId, id); // ensures ownership + throws if missing
+
+    return this.prisma.challenge.update({
+      where: { id },
+      data: { status },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-private helper
+// ---------------------------------------------------------------------------
+
+function getCurrentWeek(): { weekStart: Date; weekEnd: Date } {
+  const now = new Date();
+  const day = now.getDay(); // 0 = Sunday
+  const weekStart = new Date(now);
+  weekStart.setDate(now.getDate() - day);
+  weekStart.setHours(0, 0, 0, 0);
+
+  const weekEnd = new Date(weekStart);
+  weekEnd.setDate(weekStart.getDate() + 6);
+  weekEnd.setHours(23, 59, 59, 999);
+
+  return { weekStart, weekEnd };
+}

--- a/apps/api/src/challenges/dto/update-challenge-status.dto.ts
+++ b/apps/api/src/challenges/dto/update-challenge-status.dto.ts
@@ -1,0 +1,5 @@
+import type { ChallengeStatus } from '@financial-advisor/shared';
+
+export class UpdateChallengeStatusDto {
+  status: ChallengeStatus;
+}


### PR DESCRIPTION
Closes #11

## Changes
- `ChallengesService`:
  - `generate` — computes current week (Sun–Sat), fetches last 50 transactions, calls `AiService.generateWeeklyChallenge`, persists result
  - `findAll` — returns user's challenges ordered by `weekStart` desc
  - `findOne` — scoped to authenticated user, throws `NotFoundException`
  - `updateStatus` — validates ownership via `findOne`, then updates `ACTIVE | COMPLETED | FAILED`
- `ChallengesController` — `POST /challenges/generate`, `GET /challenges`, `GET /challenges/:id`, `PATCH /challenges/:id/status`, all behind `JwtAuthGuard`
- 14 unit tests across service (9) and controller (5), all passing

## Commits
- `feat(challenges): add UpdateChallengeStatusDto`
- `feat(challenges): add ChallengesService with AI weekly challenge generation`
- `feat(challenges): add ChallengesController and wire ChallengesModule`
- `test(challenges): add unit tests for ChallengesService`
- `test(challenges): add unit tests for ChallengesController`