### PR TITLE
feat: implement Login/Register screens with Zustand auth store

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,31 +13,121 @@ financial-advisor/
     └── shared/     # Shared TypeScript types
 ```
 
-## Quick Start
+---
+
+## Prerequisites
+
+- **Node.js** 22+
+- **npm** 10+
+- **PostgreSQL** 14+ running locally
+- **Expo Go** app installed on your iOS/Android device (for physical device testing)
+
+---
+
+## First-Time Setup
+
+### 1. Install dependencies
 
 ```bash
-# Install all dependencies
 npm install
+```
 
-# Start the API (requires PostgreSQL running)
-npm run api
+### 2. Set up the API environment
 
-# Start the mobile app
-npm run mobile
+Create `apps/api/.env`:
 
-# Run DB migrations
+```env
+DATABASE_URL="postgresql://<your-pg-user>@localhost:5432/financial_advisor"
+JWT_ACCESS_SECRET="your-random-access-secret"
+JWT_REFRESH_SECRET="your-random-refresh-secret"
+JWT_ACCESS_EXPIRY="15m"
+JWT_REFRESH_EXPIRY="7d"
+ANTHROPIC_API_KEY="sk-ant-..."
+PORT=3000
+```
+
+> Replace `<your-pg-user>` with your local PostgreSQL username (e.g. `saharsh` or `postgres`).
+
+### 3. Create the database
+
+```bash
+psql -d postgres -c "CREATE DATABASE financial_advisor;"
+```
+
+### 4. Run database migrations
+
+```bash
 npm run db:migrate
 ```
 
-## Environment Setup
+### 5. Set up the mobile environment (optional)
 
-Copy `apps/api/.env.example` to `apps/api/.env` and fill in:
-- `DATABASE_URL` – PostgreSQL connection string
-- `ANTHROPIC_API_KEY` – your Anthropic API key
-- `JWT_ACCESS_SECRET` / `JWT_REFRESH_SECRET` – random secrets
+Create `apps/mobile/.env` only if you need to override the API URL (e.g. using a physical device over a different network):
 
-## Sprint 1 Features
+```env
+EXPO_PUBLIC_API_URL=http://<your-mac-lan-ip>:3000/api
+```
+
+> **On the same WiFi network, this file is not needed.** The mobile app auto-detects the Mac's LAN IP from the Metro bundler host and connects to port 3000 automatically.
+
+---
+
+## Running Locally
+
+Open two terminal windows from the project root:
+
+```bash
+# Terminal 1 — start the NestJS API
+npm run api
+
+# Terminal 2 — start the Expo mobile app
+npm run mobile
+```
+
+- API will be available at `http://localhost:3000/api`
+- Expo will print a QR code — scan it with Expo Go on your device
+
+### How the mobile app finds the API
+
+The app uses `expo-constants` to read the Metro bundler's host (e.g. `192.168.1.5:8081`) and automatically points to `http://192.168.1.5:3000/api`. This works automatically when your Mac and device are on the same WiFi network.
+
+If you're using **Expo tunnel mode** (`npm run mobile:tunnel`), the auto-detection won't work. In that case, set `EXPO_PUBLIC_API_URL` in `apps/mobile/.env` to your Mac's LAN IP:
+
+```env
+EXPO_PUBLIC_API_URL=http://192.168.1.5:3000/api
+```
+
+> Keep the API running locally on port 3000 — do not tunnel the API. This way NestJS request logs remain visible in your terminal.
+
+---
+
+## Available Scripts
+
+All scripts run from the **monorepo root**:
+
+| Script | Description |
+|---|---|
+| `npm run api` | Start NestJS API in watch/dev mode |
+| `npm run api:prod` | Start NestJS API in production mode |
+| `npm run mobile` | Start Expo Metro bundler |
+| `npm run mobile:tunnel` | Start Expo with tunnel (for remote devices) |
+| `npm run mobile:android` | Start Expo targeting Android |
+| `npm run mobile:ios` | Start Expo targeting iOS |
+| `npm run test` | Run all tests (API + mobile) |
+| `npm run test:api` | Run API unit tests only |
+| `npm run test:mobile` | Run mobile unit tests only |
+| `npm run db:migrate` | Run Prisma migrations (dev) |
+| `npm run db:migrate:prod` | Run Prisma migrations (production) |
+| `npm run db:studio` | Open Prisma Studio GUI |
+| `npm run db:generate` | Regenerate Prisma client |
+| `npm run build:shared` | Build shared TypeScript package |
+
+---
+
+## Features
+
+- JWT authentication (register, login, token refresh)
 - Automated transaction categorization via AI
-- Spending insights (weekly/monthly)
-- Savings goal recommendations
-- AI-generated weekly challenges
+- Spending insights (weekly/monthly AI analysis)
+- Savings goal creation with AI recommendations
+- AI-generated weekly financial challenges

--- a/apps/mobile/jest.setup.js
+++ b/apps/mobile/jest.setup.js
@@ -1,0 +1,7 @@
+// Mock Expo's lazily-installed globals to avoid "import outside test scope" errors
+globalThis.__ExpoImportMetaRegistry = { url: 'file://test' };
+
+// structuredClone is built-in in Node 17+; polyfill for older Jest environments
+if (typeof globalThis.structuredClone === 'undefined') {
+  globalThis.structuredClone = (obj) => JSON.parse(JSON.stringify(obj));
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -27,6 +27,7 @@
     "@react-navigation/native-stack": "^7.14.4",
     "axios": "^1.13.6",
     "expo": "~54.0.0",
+    "expo-constants": "^55.0.7",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,20 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "setupFiles": [
+      "./jest.setup.js"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
+    ],
+    "moduleNameMapper": {
+      "^@financial-advisor/shared$": "<rootDir>/../../packages/shared/src/index.ts"
+    }
   },
   "dependencies": {
     "@react-navigation/bottom-tabs": "^7.15.5",
@@ -22,7 +35,10 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@testing-library/react-native": "^13.3.3",
+    "@types/jest": "^30.0.0",
     "@types/react": "~19.1.10",
+    "jest-expo": "^55.0.9",
     "typescript": "~5.9.2"
   },
   "private": true

--- a/apps/mobile/src/navigation/index.tsx
+++ b/apps/mobile/src/navigation/index.tsx
@@ -12,15 +12,17 @@ import LoginScreen from '../screens/Auth/LoginScreen';
 import RegisterScreen from '../screens/Auth/RegisterScreen';
 import DashboardScreen from '../screens/Dashboard/DashboardScreen';
 import TransactionsScreen from '../screens/Transactions/TransactionsScreen';
+import AddTransactionScreen from '../screens/Transactions/AddTransactionScreen';
 import GoalsScreen from '../screens/Goals/GoalsScreen';
 import ChallengeScreen from '../screens/Challenge/ChallengeScreen';
 
-import type { AuthStackParamList, AppTabParamList } from './types';
+import type { AuthStackParamList, AppTabParamList, AppStackParamList } from './types';
 
 // ---------------------------------------------------------------------------
 // Stack + Tab instances
 // ---------------------------------------------------------------------------
 const AuthStack = createNativeStackNavigator<AuthStackParamList>();
+const AppStack  = createNativeStackNavigator<AppStackParamList>();
 const AppTabs   = createBottomTabNavigator<AppTabParamList>();
 
 // ---------------------------------------------------------------------------
@@ -112,6 +114,22 @@ function AppNavigator() {
 }
 
 // ---------------------------------------------------------------------------
+// App root stack — tabs + modal screens (e.g. AddTransaction)
+// ---------------------------------------------------------------------------
+function AppRootNavigator() {
+  return (
+    <AppStack.Navigator screenOptions={{ headerShown: false }}>
+      <AppStack.Screen name="AppTabs" component={AppNavigator} />
+      <AppStack.Screen
+        name="AddTransaction"
+        component={AddTransactionScreen}
+        options={{ presentation: 'modal' }}
+      />
+    </AppStack.Navigator>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Root navigator — switches stacks reactively via Zustand auth state
 // ---------------------------------------------------------------------------
 export default function RootNavigator() {
@@ -119,7 +137,7 @@ export default function RootNavigator() {
 
   return (
     <NavigationContainer>
-      {isAuthenticated ? <AppNavigator /> : <AuthNavigator />}
+      {isAuthenticated ? <AppRootNavigator /> : <AuthNavigator />}
     </NavigationContainer>
   );
 }

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -20,7 +20,16 @@ export type AppTabParamList = {
 };
 
 // ---------------------------------------------------------------------------
+// Root app stack — wraps tabs + modal screens
+// ---------------------------------------------------------------------------
+export type AppStackParamList = {
+  AppTabs:        undefined;
+  AddTransaction: undefined;
+};
+
+// ---------------------------------------------------------------------------
 // Typed navigation props — import these in screens instead of casting
 // ---------------------------------------------------------------------------
-export type AuthNavProp    = NativeStackNavigationProp<AuthStackParamList>;
-export type AppTabNavProp  = BottomTabNavigationProp<AppTabParamList>;
+export type AuthNavProp     = NativeStackNavigationProp<AuthStackParamList>;
+export type AppTabNavProp   = BottomTabNavigationProp<AppTabParamList>;
+export type AppStackNavProp = NativeStackNavigationProp<AppStackParamList>;

--- a/apps/mobile/src/screens/Auth/LoginScreen.tsx
+++ b/apps/mobile/src/screens/Auth/LoginScreen.tsx
@@ -1,33 +1,154 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { colors, spacing, typography } from '../../theme';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  KeyboardAvoidingView,
+  ScrollView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { colors, spacing, radius, typography } from '../../theme';
 import { strings } from '../../content/strings';
+import { useAuthStore } from '../../store/authStore';
+import type { AuthNavProp } from '../../navigation/types';
 
-// TODO(Issue #13): Implement full login form with Zustand auth store integration
 export default function LoginScreen() {
+  const navigation = useNavigation<AuthNavProp>();
+  const login = useAuthStore((s) => s.login);
+
+  const [email, setEmail]       = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading]   = useState(false);
+  const [error, setError]       = useState('');
+
+  function validate(): boolean {
+    if (!email.trim()) { setError(strings.errors.requiredField); return false; }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) { setError(strings.errors.invalidEmail); return false; }
+    if (!password) { setError(strings.errors.requiredField); return false; }
+    return true;
+  }
+
+  async function handleLogin() {
+    setError('');
+    if (!validate()) return;
+    setLoading(true);
+    try {
+      await login({ email: email.trim().toLowerCase(), password });
+      // RootNavigator switches to AppTabs automatically when isAuthenticated → true
+    } catch {
+      setError(strings.errors.loginFailed);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.appName}>{strings.app.name}</Text>
-      <Text style={styles.title}>{strings.auth.login.title}</Text>
-      <Text style={styles.subtitle}>{strings.auth.login.subtitle}</Text>
-    </View>
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* ── Logo ── */}
+        <Text style={styles.appName}>{strings.app.name}</Text>
+        <Text style={styles.tagline}>{strings.app.tagline}</Text>
+
+        {/* ── Card ── */}
+        <View style={styles.card}>
+          <Text style={styles.title}>{strings.auth.login.title}</Text>
+          <Text style={styles.subtitle}>{strings.auth.login.subtitle}</Text>
+
+          <Text style={styles.label}>{strings.auth.login.emailLabel}</Text>
+          <TextInput
+            style={styles.input}
+            placeholder={strings.auth.login.emailPlaceholder}
+            placeholderTextColor={colors.textMuted}
+            value={email}
+            onChangeText={setEmail}
+            autoCapitalize="none"
+            keyboardType="email-address"
+            autoComplete="email"
+            returnKeyType="next"
+          />
+
+          <Text style={styles.label}>{strings.auth.login.passwordLabel}</Text>
+          <TextInput
+            style={styles.input}
+            placeholder={strings.auth.login.passwordPlaceholder}
+            placeholderTextColor={colors.textMuted}
+            value={password}
+            onChangeText={setPassword}
+            secureTextEntry
+            autoComplete="password"
+            returnKeyType="done"
+            onSubmitEditing={handleLogin}
+          />
+
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+
+          <TouchableOpacity
+            style={[styles.button, loading && styles.buttonDisabled]}
+            onPress={handleLogin}
+            disabled={loading}
+            activeOpacity={0.8}
+          >
+            {loading
+              ? <ActivityIndicator color={colors.textInverse} />
+              : <Text style={styles.buttonText}>{strings.auth.login.submitButton}</Text>
+            }
+          </TouchableOpacity>
+
+          <View style={styles.footer}>
+            <Text style={styles.footerText}>{strings.auth.login.noAccount} </Text>
+            <TouchableOpacity onPress={() => navigation.navigate('Register')}>
+              <Text style={styles.link}>{strings.auth.login.registerLink}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  flex: {
     flex:            1,
     backgroundColor: colors.background,
-    justifyContent:  'center',
-    alignItems:      'center',
-    padding:         spacing['6'],
+  },
+  scroll: {
+    flexGrow:       1,
+    justifyContent: 'center',
+    padding:        spacing['6'],
   },
   appName: {
-    fontSize:   typography.size['3xl'],
-    fontWeight: typography.weight.bold,
-    color:      colors.primary,
-    marginBottom: spacing['2'],
+    fontSize:      typography.size['3xl'],
+    fontWeight:    typography.weight.bold,
+    color:         colors.primary,
+    textAlign:     'center',
+    marginBottom:  spacing['1'],
     letterSpacing: -0.5,
+  },
+  tagline: {
+    fontSize:     typography.size.sm,
+    color:        colors.textMuted,
+    textAlign:    'center',
+    marginBottom: spacing['8'],
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius:    radius.xl,
+    padding:         spacing['6'],
+    shadowColor:     colors.textPrimary,
+    shadowOffset:    { width: 0, height: 2 },
+    shadowOpacity:   0.06,
+    shadowRadius:    12,
+    elevation:       3,
   },
   title: {
     fontSize:     typography.size.xl,
@@ -36,7 +157,59 @@ const styles = StyleSheet.create({
     marginBottom: spacing['1'],
   },
   subtitle: {
-    fontSize: typography.size.base,
+    fontSize:     typography.size.sm,
+    color:        colors.textSecondary,
+    marginBottom: spacing['6'],
+  },
+  label: {
+    fontSize:     typography.size.sm,
+    fontWeight:   typography.weight.medium,
+    color:        colors.textPrimary,
+    marginBottom: spacing['1'],
+  },
+  input: {
+    backgroundColor:   colors.surfaceAlt,
+    borderWidth:       1,
+    borderColor:       colors.border,
+    borderRadius:      radius.md,
+    paddingHorizontal: spacing['4'],
+    paddingVertical:   spacing['3'],
+    fontSize:          typography.size.base,
+    color:             colors.textPrimary,
+    marginBottom:      spacing['4'],
+  },
+  error: {
+    fontSize:     typography.size.sm,
+    color:        colors.danger,
+    marginBottom: spacing['3'],
+  },
+  button: {
+    backgroundColor: colors.primary,
+    borderRadius:    radius.md,
+    paddingVertical: spacing['4'],
+    alignItems:      'center',
+    marginBottom:    spacing['4'],
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color:      colors.textInverse,
+    fontSize:   typography.size.base,
+    fontWeight: typography.weight.semibold,
+  },
+  footer: {
+    flexDirection:  'row',
+    justifyContent: 'center',
+    alignItems:     'center',
+  },
+  footerText: {
+    fontSize: typography.size.sm,
     color:    colors.textSecondary,
+  },
+  link: {
+    fontSize:   typography.size.sm,
+    color:      colors.primary,
+    fontWeight: typography.weight.semibold,
   },
 });

--- a/apps/mobile/src/screens/Auth/RegisterScreen.tsx
+++ b/apps/mobile/src/screens/Auth/RegisterScreen.tsx
@@ -1,25 +1,165 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { colors, spacing, typography } from '../../theme';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  KeyboardAvoidingView,
+  ScrollView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { colors, spacing, radius, typography } from '../../theme';
 import { strings } from '../../content/strings';
+import { useAuthStore } from '../../store/authStore';
+import type { AuthNavProp } from '../../navigation/types';
 
-// TODO(Issue #13): Implement full registration form with Zustand auth store integration
 export default function RegisterScreen() {
+  const navigation = useNavigation<AuthNavProp>();
+  const register = useAuthStore((s) => s.register);
+
+  const [name, setName]         = useState('');
+  const [email, setEmail]       = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading]   = useState(false);
+  const [error, setError]       = useState('');
+
+  function validate(): boolean {
+    if (!name.trim()) { setError(strings.errors.requiredField); return false; }
+    if (!email.trim()) { setError(strings.errors.requiredField); return false; }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) { setError(strings.errors.invalidEmail); return false; }
+    if (password.length < 8) { setError(strings.errors.passwordTooShort); return false; }
+    return true;
+  }
+
+  async function handleRegister() {
+    setError('');
+    if (!validate()) return;
+    setLoading(true);
+    try {
+      await register({ name: name.trim(), email: email.trim().toLowerCase(), password });
+    } catch {
+      setError(strings.errors.registerFailed);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{strings.auth.register.title}</Text>
-      <Text style={styles.subtitle}>{strings.auth.register.subtitle}</Text>
-    </View>
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={styles.appName}>{strings.app.name}</Text>
+        <Text style={styles.tagline}>{strings.app.tagline}</Text>
+
+        <View style={styles.card}>
+          <Text style={styles.title}>{strings.auth.register.title}</Text>
+          <Text style={styles.subtitle}>{strings.auth.register.subtitle}</Text>
+
+          <Text style={styles.label}>{strings.auth.register.nameLabel}</Text>
+          <TextInput
+            style={styles.input}
+            placeholder={strings.auth.register.namePlaceholder}
+            placeholderTextColor={colors.textMuted}
+            value={name}
+            onChangeText={setName}
+            autoCapitalize="words"
+            autoComplete="name"
+            returnKeyType="next"
+          />
+
+          <Text style={styles.label}>{strings.auth.register.emailLabel}</Text>
+          <TextInput
+            style={styles.input}
+            placeholder={strings.auth.register.emailPlaceholder}
+            placeholderTextColor={colors.textMuted}
+            value={email}
+            onChangeText={setEmail}
+            autoCapitalize="none"
+            keyboardType="email-address"
+            autoComplete="email"
+            returnKeyType="next"
+          />
+
+          <Text style={styles.label}>{strings.auth.register.passwordLabel}</Text>
+          <TextInput
+            style={styles.input}
+            placeholder={strings.auth.register.passwordPlaceholder}
+            placeholderTextColor={colors.textMuted}
+            value={password}
+            onChangeText={setPassword}
+            secureTextEntry
+            autoComplete="new-password"
+            returnKeyType="done"
+            onSubmitEditing={handleRegister}
+          />
+
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+
+          <TouchableOpacity
+            style={[styles.button, loading && styles.buttonDisabled]}
+            onPress={handleRegister}
+            disabled={loading}
+            activeOpacity={0.8}
+          >
+            {loading
+              ? <ActivityIndicator color={colors.textInverse} />
+              : <Text style={styles.buttonText}>{strings.auth.register.submitButton}</Text>
+            }
+          </TouchableOpacity>
+
+          <View style={styles.footer}>
+            <Text style={styles.footerText}>{strings.auth.register.hasAccount} </Text>
+            <TouchableOpacity onPress={() => navigation.navigate('Login')}>
+              <Text style={styles.link}>{strings.auth.register.loginLink}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  flex: {
     flex:            1,
     backgroundColor: colors.background,
-    justifyContent:  'center',
-    alignItems:      'center',
+  },
+  scroll: {
+    flexGrow:       1,
+    justifyContent: 'center',
+    padding:        spacing['6'],
+  },
+  appName: {
+    fontSize:      typography.size['3xl'],
+    fontWeight:    typography.weight.bold,
+    color:         colors.primary,
+    textAlign:     'center',
+    marginBottom:  spacing['1'],
+    letterSpacing: -0.5,
+  },
+  tagline: {
+    fontSize:     typography.size.sm,
+    color:        colors.textMuted,
+    textAlign:    'center',
+    marginBottom: spacing['8'],
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius:    radius.xl,
     padding:         spacing['6'],
+    shadowColor:     colors.textPrimary,
+    shadowOffset:    { width: 0, height: 2 },
+    shadowOpacity:   0.06,
+    shadowRadius:    12,
+    elevation:       3,
   },
   title: {
     fontSize:     typography.size.xl,
@@ -28,7 +168,59 @@ const styles = StyleSheet.create({
     marginBottom: spacing['1'],
   },
   subtitle: {
-    fontSize: typography.size.base,
+    fontSize:     typography.size.sm,
+    color:        colors.textSecondary,
+    marginBottom: spacing['6'],
+  },
+  label: {
+    fontSize:     typography.size.sm,
+    fontWeight:   typography.weight.medium,
+    color:        colors.textPrimary,
+    marginBottom: spacing['1'],
+  },
+  input: {
+    backgroundColor:   colors.surfaceAlt,
+    borderWidth:       1,
+    borderColor:       colors.border,
+    borderRadius:      radius.md,
+    paddingHorizontal: spacing['4'],
+    paddingVertical:   spacing['3'],
+    fontSize:          typography.size.base,
+    color:             colors.textPrimary,
+    marginBottom:      spacing['4'],
+  },
+  error: {
+    fontSize:     typography.size.sm,
+    color:        colors.danger,
+    marginBottom: spacing['3'],
+  },
+  button: {
+    backgroundColor: colors.primary,
+    borderRadius:    radius.md,
+    paddingVertical: spacing['4'],
+    alignItems:      'center',
+    marginBottom:    spacing['4'],
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color:      colors.textInverse,
+    fontSize:   typography.size.base,
+    fontWeight: typography.weight.semibold,
+  },
+  footer: {
+    flexDirection:  'row',
+    justifyContent: 'center',
+    alignItems:     'center',
+  },
+  footerText: {
+    fontSize: typography.size.sm,
     color:    colors.textSecondary,
+  },
+  link: {
+    fontSize:   typography.size.sm,
+    color:      colors.primary,
+    fontWeight: typography.weight.semibold,
   },
 });

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -1,11 +1,35 @@
 import axios from 'axios';
+import Constants from 'expo-constants';
 import type { AuthTokens } from '@financial-advisor/shared';
 
-const API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000/api';
+/**
+ * Resolve the API base URL for any run environment:
+ *   - Set EXPO_PUBLIC_API_URL in .env to override explicitly (production, tunnels, etc.)
+ *   - Otherwise, derive from the Expo/Metro dev-server host so it works on:
+ *       • iOS Simulator   → localhost
+ *       • Android Emulator → LAN IP that Metro is already using
+ *       • Physical device  → LAN IP that Metro is already using
+ */
+function resolveApiUrl(): string {
+  const envUrl = process.env.EXPO_PUBLIC_API_URL;
+  if (envUrl) return envUrl;
+
+  // hostUri is e.g. "192.168.1.5:8081" or "localhost:8081"
+  const hostUri = Constants.expoConfig?.hostUri ?? (Constants as any).manifest?.debuggerHost;
+  if (hostUri) {
+    const host = hostUri.split(':')[0];
+    return `http://${host}:3000/api`;
+  }
+
+  return 'http://localhost:3000/api';
+}
+
+const API_URL = resolveApiUrl();
 
 const api = axios.create({
   baseURL: API_URL,
   headers: { 'Content-Type': 'application/json' },
+  timeout: 10000, // 10 s — prevents infinite loading when server is unreachable
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -12,13 +12,31 @@ import type { AuthTokens } from '@financial-advisor/shared';
  */
 function resolveApiUrl(): string {
   const envUrl = process.env.EXPO_PUBLIC_API_URL;
-  if (envUrl) return envUrl;
 
-  // hostUri is e.g. "192.168.1.5:8081" or "localhost:8081"
+  // Explicit env var wins — use it when it's a real external URL (tunnel, prod, etc.)
+  // Skip localhost/127.0.0.1 — those only work on the Mac itself, not on devices.
+  if (envUrl && !envUrl.includes('localhost') && !envUrl.includes('127.0.0.1')) {
+    if (__DEV__) console.log('[api] using env URL:', envUrl);
+    return envUrl;
+  }
+
+  // Auto-detect the Mac's LAN IP from Metro's hostUri.
+  // Skip *.exp.direct — that's Expo's own tunnel, not the API host.
   const hostUri = Constants.expoConfig?.hostUri ?? (Constants as any).manifest?.debuggerHost;
-  if (hostUri) {
-    const host = hostUri.split(':')[0];
-    return `http://${host}:3000/api`;
+  if (hostUri && !hostUri.includes('.exp.direct')) {
+    const host = hostUri.split(':')[0]; // e.g. "192.168.1.5" from "192.168.1.5:8081"
+    const url = `http://${host}:3000/api`;
+    if (__DEV__) console.log('[api] auto-detected LAN URL:', url);
+    return url;
+  }
+
+  // Expo tunnel mode and no env var set — log a clear warning.
+  if (__DEV__) {
+    console.warn(
+      '[api] Using Expo tunnel but EXPO_PUBLIC_API_URL is not set.\n' +
+      'Run: npx localtunnel --port 3000\n' +
+      'Then set EXPO_PUBLIC_API_URL=https://<your-lt-url>/api in apps/mobile/.env',
+    );
   }
 
   return 'http://localhost:3000/api';

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -1,11 +1,88 @@
 import axios from 'axios';
+import type { AuthTokens } from '@financial-advisor/shared';
 
-// TODO(Issue #18): Add request interceptor to attach JWT from auth store
 const API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000/api';
 
 const api = axios.create({
   baseURL: API_URL,
   headers: { 'Content-Type': 'application/json' },
 });
+
+// ---------------------------------------------------------------------------
+// Request interceptor — attach JWT access token from auth store
+// ---------------------------------------------------------------------------
+api.interceptors.request.use((config) => {
+  // Lazy require breaks the circular import: api ↔ authStore
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useAuthStore } = require('../store/authStore') as typeof import('../store/authStore');
+  const tokens = useAuthStore.getState().tokens;
+  if (tokens?.accessToken) {
+    config.headers.Authorization = `Bearer ${tokens.accessToken}`;
+  }
+  return config;
+});
+
+// ---------------------------------------------------------------------------
+// Response interceptor — 401 → refresh token → retry original request
+// ---------------------------------------------------------------------------
+let isRefreshing = false;
+type QueueEntry = { resolve: (token: string) => void; reject: (err: unknown) => void };
+let failedQueue: QueueEntry[] = [];
+
+function processQueue(error: unknown, token: string | null = null): void {
+  failedQueue.forEach(({ resolve, reject }) => {
+    if (error) reject(error);
+    else resolve(token as string);
+  });
+  failedQueue = [];
+}
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config as typeof error.config & { _retry?: boolean };
+
+    if (error.response?.status !== 401 || originalRequest._retry) {
+      return Promise.reject(error);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useAuthStore } = require('../store/authStore') as typeof import('../store/authStore');
+    const { tokens, setTokens, logout } = useAuthStore.getState();
+
+    if (!tokens?.refreshToken) {
+      logout();
+      return Promise.reject(error);
+    }
+
+    if (isRefreshing) {
+      return new Promise<string>((resolve, reject) => {
+        failedQueue.push({ resolve, reject });
+      }).then((newAccessToken) => {
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return api(originalRequest);
+      });
+    }
+
+    originalRequest._retry = true;
+    isRefreshing = true;
+
+    try {
+      const { data } = await axios.post<AuthTokens>(`${API_URL}/auth/refresh`, {
+        refreshToken: tokens.refreshToken,
+      });
+      setTokens(data);
+      processQueue(null, data.accessToken);
+      originalRequest.headers.Authorization = `Bearer ${data.accessToken}`;
+      return api(originalRequest);
+    } catch (refreshError) {
+      processQueue(refreshError, null);
+      logout();
+      return Promise.reject(refreshError);
+    } finally {
+      isRefreshing = false;
+    }
+  },
+);
 
 export default api;

--- a/apps/mobile/src/store/__tests__/authStore.test.ts
+++ b/apps/mobile/src/store/__tests__/authStore.test.ts
@@ -1,0 +1,107 @@
+import { useAuthStore } from '../authStore';
+
+// Mock the api module
+jest.mock('../../services/api', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+  },
+}));
+
+import api from '../../services/api';
+
+const mockApi = api as jest.Mocked<typeof api>;
+
+const mockUser = { id: '1', email: 'test@example.com', name: 'Test', authProvider: 'LOCAL' as const };
+const mockTokens = { accessToken: 'access-token', refreshToken: 'refresh-token' };
+const mockResponse = { user: mockUser, tokens: mockTokens };
+
+beforeEach(() => {
+  // Reset store state
+  useAuthStore.setState({ user: null, tokens: null, isAuthenticated: false });
+  jest.clearAllMocks();
+});
+
+describe('authStore', () => {
+  it('initialises with unauthenticated state', () => {
+    const { user, tokens, isAuthenticated } = useAuthStore.getState();
+    expect(user).toBeNull();
+    expect(tokens).toBeNull();
+    expect(isAuthenticated).toBe(false);
+  });
+
+  describe('login', () => {
+    it('sets user and tokens on success', async () => {
+      (mockApi.post as jest.Mock).mockResolvedValueOnce({ data: mockResponse });
+      await useAuthStore.getState().login({ email: 'test@example.com', password: 'pass1234' });
+      const { user, tokens, isAuthenticated } = useAuthStore.getState();
+      expect(user).toEqual(mockUser);
+      expect(tokens).toEqual(mockTokens);
+      expect(isAuthenticated).toBe(true);
+    });
+
+    it('posts to /auth/login with credentials', async () => {
+      (mockApi.post as jest.Mock).mockResolvedValueOnce({ data: mockResponse });
+      await useAuthStore.getState().login({ email: 'test@example.com', password: 'pass1234' });
+      expect(mockApi.post).toHaveBeenCalledWith('/auth/login', {
+        email: 'test@example.com',
+        password: 'pass1234',
+      });
+    });
+
+    it('propagates API errors', async () => {
+      (mockApi.post as jest.Mock).mockRejectedValueOnce(new Error('Unauthorized'));
+      await expect(
+        useAuthStore.getState().login({ email: 'bad@example.com', password: 'wrong' }),
+      ).rejects.toThrow('Unauthorized');
+    });
+  });
+
+  describe('register', () => {
+    it('sets user and tokens on success', async () => {
+      (mockApi.post as jest.Mock).mockResolvedValueOnce({ data: mockResponse });
+      await useAuthStore.getState().register({ name: 'Test', email: 'test@example.com', password: 'pass1234' });
+      const { user, tokens, isAuthenticated } = useAuthStore.getState();
+      expect(user).toEqual(mockUser);
+      expect(tokens).toEqual(mockTokens);
+      expect(isAuthenticated).toBe(true);
+    });
+
+    it('posts to /auth/register', async () => {
+      (mockApi.post as jest.Mock).mockResolvedValueOnce({ data: mockResponse });
+      await useAuthStore.getState().register({ name: 'Test', email: 'test@example.com', password: 'pass1234' });
+      expect(mockApi.post).toHaveBeenCalledWith('/auth/register', {
+        name: 'Test',
+        email: 'test@example.com',
+        password: 'pass1234',
+      });
+    });
+  });
+
+  describe('logout', () => {
+    it('clears auth state', async () => {
+      useAuthStore.setState({ user: mockUser, tokens: mockTokens, isAuthenticated: true });
+      useAuthStore.getState().logout();
+      const { user, tokens, isAuthenticated } = useAuthStore.getState();
+      expect(user).toBeNull();
+      expect(tokens).toBeNull();
+      expect(isAuthenticated).toBe(false);
+    });
+  });
+
+  describe('setTokens', () => {
+    it('updates tokens without touching user or auth flag', () => {
+      useAuthStore.setState({ user: mockUser, tokens: mockTokens, isAuthenticated: true });
+      const newTokens = { accessToken: 'new-access', refreshToken: 'new-refresh' };
+      useAuthStore.getState().setTokens(newTokens);
+      const { tokens, user, isAuthenticated } = useAuthStore.getState();
+      expect(tokens).toEqual(newTokens);
+      expect(user).toEqual(mockUser);
+      expect(isAuthenticated).toBe(true);
+    });
+  });
+});

--- a/apps/mobile/src/store/authStore.ts
+++ b/apps/mobile/src/store/authStore.ts
@@ -1,15 +1,34 @@
 import { create } from 'zustand';
-import type { AuthUser, AuthTokens } from '@financial-advisor/shared';
+import type { AuthUser, AuthTokens, AuthResponse, LoginDto, RegisterDto } from '@financial-advisor/shared';
+import api from '../services/api';
 
-// TODO(Issue #13): Add login, register, logout actions
 interface AuthState {
   user: AuthUser | null;
   tokens: AuthTokens | null;
   isAuthenticated: boolean;
+  // Actions
+  login: (dto: LoginDto) => Promise<void>;
+  register: (dto: RegisterDto) => Promise<void>;
+  logout: () => void;
+  setTokens: (tokens: AuthTokens) => void;
 }
 
-export const useAuthStore = create<AuthState>()(() => ({
+export const useAuthStore = create<AuthState>()((set) => ({
   user: null,
   tokens: null,
   isAuthenticated: false,
+
+  login: async (dto) => {
+    const { data } = await api.post<AuthResponse>('/auth/login', dto);
+    set({ user: data.user, tokens: data.tokens, isAuthenticated: true });
+  },
+
+  register: async (dto) => {
+    const { data } = await api.post<AuthResponse>('/auth/register', dto);
+    set({ user: data.user, tokens: data.tokens, isAuthenticated: true });
+  },
+
+  logout: () => set({ user: null, tokens: null, isAuthenticated: false }),
+
+  setTokens: (tokens) => set({ tokens }),
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@prisma/client": "^7.4.2",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
-        "class-validator": "^0.14.1",
+        "class-validator": "^0.15.1",
         "dotenv": "^17.3.1",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -90,6 +90,7 @@
         "@react-navigation/native-stack": "^7.14.4",
         "axios": "^1.13.6",
         "expo": "~54.0.0",
+        "expo-constants": "^55.0.7",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -103,6 +104,91 @@
         "@types/react": "~19.1.10",
         "jest-expo": "^55.0.9",
         "typescript": "~5.9.2"
+      }
+    },
+    "apps/mobile/node_modules/@expo/config": {
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.8.tgz",
+      "integrity": "sha512-D7RYYHfErCgEllGxNwdYdkgzLna7zkzUECBV3snbUpf7RvIpB5l1LpCgzuVoc5KVew5h7N1Tn4LnT/tBSUZsQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "~55.0.6",
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "^10.0.12",
+        "@expo/require-utils": "^55.0.2",
+        "deepmerge": "^4.3.1",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4"
+      }
+    },
+    "apps/mobile/node_modules/@expo/config-plugins": {
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.6.tgz",
+      "integrity": "sha512-cIox6FjZlFaaX40rbQ3DvP9e87S5X85H9uw+BAxJE5timkMhuByy3GAlOsj1h96EyzSiol7Q6YIGgY1Jiz4M+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "~10.0.12",
+        "@expo/plist": "^0.5.2",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "apps/mobile/node_modules/@expo/config-types": {
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
+      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
+      "license": "MIT"
+    },
+    "apps/mobile/node_modules/@expo/env": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.1.1.tgz",
+      "integrity": "sha512-rVvHC4I6xlPcg+mAO09ydUi2Wjv1ZytpLmHOSzvXzBAz9mMrJggqCe4s4dubjJvi/Ino/xQCLhbaLCnTtLpikg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "getenv": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.12.0"
+      }
+    },
+    "apps/mobile/node_modules/@expo/plist": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
+      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "apps/mobile/node_modules/expo-constants": {
+      "version": "55.0.7",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.7.tgz",
+      "integrity": "sha512-kdcO4TsQRRqt0USvjaY5vgQMO9H52K3kBZ/ejC7F6rz70mv08GoowrZ1CYOr5O4JpPDRlIpQfZJUucaS/c+KWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~55.0.8",
+        "@expo/env": "~2.1.1"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -2038,6 +2124,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.1.0",
         "tslib": "^2.4.0"
@@ -2050,6 +2137,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2061,6 +2149,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3014,7 +3103,6 @@
       "version": "55.0.2",
       "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.2.tgz",
       "integrity": "sha512-dV5oCShQ1umKBKagMMT4B/N+SREsQe3lU4Zgmko5AO0rxKV0tynZT6xXs+e2JxuqT4Rz997atg7pki0BnZb4uw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -5549,6 +5637,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
@@ -6368,6 +6457,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6999,6 +7089,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -7348,7 +7439,6 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -7405,18 +7495,17 @@
         "@types/superagent": "^8.1.0"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@types/validator": {
-      "version": "13.15.10",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
-      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
-=======
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
->>>>>>> 525c892 (chore: update lockfile after adding jest-expo deps)
+      "license": "MIT"
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -7734,7 +7823,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.11.1",
@@ -7748,7 +7838,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
@@ -7762,7 +7853,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.11.1",
@@ -7776,7 +7868,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.11.1",
@@ -7790,7 +7883,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.11.1",
@@ -7804,7 +7898,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.11.1",
@@ -7818,7 +7913,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.11.1",
@@ -7832,7 +7928,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.11.1",
@@ -7846,7 +7943,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.11.1",
@@ -7860,7 +7958,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.11.1",
@@ -7874,7 +7973,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.11.1",
@@ -7888,7 +7988,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.11.1",
@@ -7902,7 +8003,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.11.1",
@@ -7916,7 +8018,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.11.1",
@@ -7930,7 +8033,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.11.1",
@@ -7942,6 +8046,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.11"
       },
@@ -7961,7 +8066,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.11.1",
@@ -7975,7 +8081,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
@@ -7989,7 +8096,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@urql/core": {
       "version": "5.2.0",
@@ -9404,9 +9512,9 @@
       "license": "MIT"
     },
     "node_modules/class-validator": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
-      "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.15.3",
@@ -9896,7 +10004,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -21424,7 +21531,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,10 @@
         "zustand": "^5.0.11"
       },
       "devDependencies": {
+        "@testing-library/react-native": "^13.3.3",
+        "@types/jest": "^30.0.0",
         "@types/react": "~19.1.10",
+        "jest-expo": "^55.0.9",
         "typescript": "~5.9.2"
       }
     },
@@ -3005,6 +3008,26 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/@expo/require-utils": {
+      "version": "55.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.2.tgz",
+      "integrity": "sha512-dV5oCShQ1umKBKagMMT4B/N+SREsQe3lU4Zgmko5AO0rxKV0tynZT6xXs+e2JxuqT4Rz997atg7pki0BnZb4uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@expo/schema-utils": {
@@ -6833,6 +6856,81 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.3.3.tgz",
+      "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.0.5",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.0.5",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -6855,6 +6953,16 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -7127,6 +7235,18 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -7228,6 +7348,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -7284,10 +7405,18 @@
         "@types/superagent": "^8.1.0"
       }
     },
+<<<<<<< HEAD
     "node_modules/@types/validator": {
       "version": "13.15.10",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
+=======
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+>>>>>>> 525c892 (chore: update lockfile after adding jest-expo deps)
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -8069,6 +8198,14 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -8110,6 +8247,17 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
       }
     },
     "node_modules/acorn-import-phases": {
@@ -9717,11 +9865,91 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -9739,6 +9967,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
@@ -9914,6 +10149,40 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -10044,6 +10313,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-editor": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-0.4.2.tgz",
@@ -10156,6 +10438,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -11831,6 +12135,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -11865,6 +12182,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/http-status-codes": {
@@ -12012,6 +12357,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -12149,6 +12504,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -13614,6 +13976,34 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -13626,6 +14016,227 @@
         "@types/node": "*",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo": {
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-55.0.9.tgz",
+      "integrity": "sha512-6wz7JJUeW2e0+APRQP7eOcXKPdI7bdmAIoBiPJbtzSBRlghho8LzPcv4jkoVFoYi8SKb9k3BTKx4GcUlyVMedw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~55.0.8",
+        "@expo/json-file": "^10.0.12",
+        "@jest/create-cache-key-function": "^29.2.1",
+        "@jest/globals": "^29.2.1",
+        "babel-jest": "^29.2.1",
+        "jest-environment-jsdom": "^29.2.1",
+        "jest-snapshot": "^29.2.1",
+        "jest-watch-select-projects": "^2.0.0",
+        "jest-watch-typeahead": "2.2.1",
+        "json5": "^2.2.3",
+        "lodash": "^4.17.19",
+        "react-test-renderer": "19.2.0",
+        "server-only": "^0.0.1",
+        "stacktrace-js": "^2.0.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*",
+        "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
+      },
+      "peerDependenciesMeta": {
+        "react-server-dom-webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-expo/node_modules/@expo/config": {
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.8.tgz",
+      "integrity": "sha512-D7RYYHfErCgEllGxNwdYdkgzLna7zkzUECBV3snbUpf7RvIpB5l1LpCgzuVoc5KVew5h7N1Tn4LnT/tBSUZsQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "~55.0.6",
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "^10.0.12",
+        "@expo/require-utils": "^55.0.2",
+        "deepmerge": "^4.3.1",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4"
+      }
+    },
+    "node_modules/jest-expo/node_modules/@expo/config-plugins": {
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.6.tgz",
+      "integrity": "sha512-cIox6FjZlFaaX40rbQ3DvP9e87S5X85H9uw+BAxJE5timkMhuByy3GAlOsj1h96EyzSiol7Q6YIGgY1Jiz4M+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "~10.0.12",
+        "@expo/plist": "^0.5.2",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/jest-expo/node_modules/@expo/config-types": {
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
+      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-expo/node_modules/@expo/plist": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
+      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/jest-expo/node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo/node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo/node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo/node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo/node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -15320,6 +15931,253 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/jest-watch-select-projects": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-watch-select-projects/-/jest-watch-select-projects-2.0.0.tgz",
+      "integrity": "sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "chalk": "^3.0.0",
+        "prompts": "^2.2.1"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-2.2.1.tgz",
+      "integrity": "sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^6.0.0",
+        "chalk": "^4.0.0",
+        "jest-regex-util": "^29.0.0",
+        "jest-watcher": "^29.0.0",
+        "slash": "^5.0.0",
+        "string-length": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "jest": "^27.0.0 || ^28.0.0 || ^29.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/@jest/console/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/jest-watcher/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/jest-watcher/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/jest-watcher/node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/jest-watcher/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/string-length": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+      "integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^2.0.0",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/string-length/node_modules/char-regex": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.2.tgz",
+      "integrity": "sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/jest-watcher": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.2.0.tgz",
@@ -15533,6 +16391,116 @@
       "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
       "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
       "license": "0BSD"
+    },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -16835,6 +17803,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -17197,6 +18175,13 @@
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
       "license": "MIT"
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nypm": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
@@ -17533,6 +18518,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -18114,36 +19112,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/prisma/node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prisma/node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
-    "node_modules/prisma/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/proc-log": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
@@ -18214,6 +19182,19 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -18280,6 +19261,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -18537,6 +19525,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-test-renderer": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.0.tgz",
+      "integrity": "sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.2.0",
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-test-renderer/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -18562,6 +19578,20 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect-metadata": {
@@ -18683,6 +19713,13 @@
       "dependencies": {
         "path-parse": "^1.0.5"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -18860,6 +19897,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -19003,6 +20053,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -19253,6 +20310,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -19279,6 +20346,39 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
@@ -19441,6 +20541,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -19598,6 +20711,13 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/synckit": {
       "version": "0.11.12",
@@ -19978,6 +21098,32 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -20278,7 +21424,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -20499,6 +21645,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-latest-callback": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
@@ -20610,6 +21767,19 @@
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -20654,56 +21824,6 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/webpack": {
-      "version": "5.105.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.8",
-        "@types/json-schema": "^7.0.15",
-        "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.28.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.20.0",
-        "es-module-lexer": "^2.0.0",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.3",
-        "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.17",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/webpack-node-externals": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
@@ -20724,110 +21844,31 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
+        "iconv-lite": "0.6.3"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12"
       }
     },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-fetch": {
@@ -20835,6 +21876,16 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -21019,6 +22070,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
@@ -21049,6 +22110,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,20 @@
     "packages/*"
   ],
   "scripts": {
-    "api": "npm run start:dev --workspace=apps/api",
-    "mobile": "npx expo start --project-directory apps/mobile",
-    "db:migrate": "npm run prisma:migrate --workspace=apps/api",
-    "db:studio": "npm run prisma:studio --workspace=apps/api",
-    "build:shared": "npm run build --workspace=packages/shared"
+    "api": "npm run start:dev -w apps/api",
+    "api:prod": "npm run start:prod -w apps/api",
+    "mobile": "npm run start -w mobile",
+    "mobile:tunnel": "npm run start -w mobile -- --tunnel",
+    "mobile:android": "npm run android -w mobile",
+    "mobile:ios": "npm run ios -w mobile",
+    "test": "npm run test -w apps/api && npm run test -w mobile",
+    "test:api": "npm run test -w apps/api",
+    "test:mobile": "npm run test -w mobile",
+    "db:migrate": "cd apps/api && npx prisma migrate dev",
+    "db:migrate:prod": "cd apps/api && npx prisma migrate deploy",
+    "db:studio": "cd apps/api && npx prisma studio",
+    "db:generate": "cd apps/api && npx prisma generate",
+    "build:shared": "npm run build -w packages/shared"
   },
   "devDependencies": {
     "typescript": "^5.8.2"


### PR DESCRIPTION
## Summary
- Wires up JWT interceptor in `api.ts` with access-token attachment and a refresh-token retry queue on 401
- Adds `login`, `register`, `logout`, `setTokens` actions to `authStore`
- Full `LoginScreen`: email + password form, validation, loading state, error display, link to Register
- Full `RegisterScreen`: name + email + password form, validation, loading state, error display, link to Login
- Adds `AddTransaction` as a modal route in a new `AppStack` wrapper so tab screens can push it
- Configures Jest (`jest-expo`) for the mobile app; 8 unit tests for `authStore` all passing

Closes #13

## Test plan
- [ ] `npm test -w mobile` → 8 tests pass
- [ ] Launch `expo start --tunnel` and verify Login screen renders with Fina brand + form fields
- [ ] Attempt login with bad credentials → error message appears
- [ ] Register a new account → lands on Dashboard tab