### PR TITLE
fix(transactions): fallback to Uncategorized when AI categorization fails

### DIFF
--- a/apps/api/src/transactions/transactions.service.spec.ts
+++ b/apps/api/src/transactions/transactions.service.spec.ts
@@ -91,6 +91,25 @@ describe('TransactionsService', () => {
       expect(result).toEqual(mockTransaction);
     });
 
+    it('should fall back to Uncategorized when AI throws', async () => {
+      mockAi.categorizeTransaction.mockRejectedValue(new Error('AI unavailable'));
+      mockPrisma.transaction.create.mockResolvedValue({
+        ...mockTransaction,
+        category: 'Uncategorized',
+        aiConfidence: null,
+      });
+
+      await service.create('user-1', {
+        description: 'Coffee',
+        amount: 5,
+        type: 'EXPENSE',
+      });
+
+      expect(mockPrisma.transaction.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ category: 'Uncategorized', aiConfidence: null }),
+      });
+    });
+
     it('should skip AI when category is provided', async () => {
       mockPrisma.transaction.create.mockResolvedValue({
         ...mockTransaction,

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -21,13 +21,17 @@ export class TransactionsService {
     let aiConfidence: number | null = null;
 
     if (!category) {
-      const result = await this.ai.categorizeTransaction(
-        dto.description,
-        dto.amount,
-        dto.type,
-      );
-      category = result.category;
-      aiConfidence = result.confidence;
+      try {
+        const result = await this.ai.categorizeTransaction(
+          dto.description,
+          dto.amount,
+          dto.type,
+        );
+        category = result.category;
+        aiConfidence = result.confidence;
+      } catch {
+        category = 'Uncategorized';
+      }
     }
 
     return this.prisma.transaction.create({


### PR DESCRIPTION
## Summary
- Wraps `ai.categorizeTransaction()` in a try/catch in `TransactionsService.create()`
- Falls back to `'Uncategorized'` category when AI is unavailable (e.g. missing API key on deployment)
- AI still runs and sets `category` + `aiConfidence` when available

## Test
- Added test: `should fall back to Uncategorized when AI throws` (11/11 passing)

Closes #40