### PR TITLE
chore(ci): add workflow_dispatch and package-lock.json path trigger

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -6,8 +6,10 @@ on:
     paths:
       - 'apps/api/**'
       - 'packages/shared/**'
+      - 'package-lock.json'
       - '.github/workflows/deploy-api.yml'
       - 'vercel.json'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` so deploys can be triggered manually from GitHub Actions UI
- Adds `package-lock.json` to the path triggers so lock file updates redeploy the API

Merging this will also trigger a fresh deploy picking up the latest `dev` code (including the AI fallback fix from #41).