### PR TITLE
fix(transactions): use Other instead of Uncategorized for AI fallback category

### DIFF
--- a/apps/api/src/transactions/transactions.service.spec.ts
+++ b/apps/api/src/transactions/transactions.service.spec.ts
@@ -91,11 +91,13 @@ describe('TransactionsService', () => {
       expect(result).toEqual(mockTransaction);
     });
 
-    it('should fall back to Uncategorized when AI throws', async () => {
-      mockAi.categorizeTransaction.mockRejectedValue(new Error('AI unavailable'));
+    it('should fall back to Other when AI throws', async () => {
+      mockAi.categorizeTransaction.mockRejectedValue(
+        new Error('AI unavailable'),
+      );
       mockPrisma.transaction.create.mockResolvedValue({
         ...mockTransaction,
-        category: 'Uncategorized',
+        category: 'Other',
         aiConfidence: null,
       });
 
@@ -106,7 +108,10 @@ describe('TransactionsService', () => {
       });
 
       expect(mockPrisma.transaction.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({ category: 'Uncategorized', aiConfidence: null }),
+        data: expect.objectContaining({
+          category: 'Other',
+          aiConfidence: null,
+        }),
       });
     });
 
@@ -125,7 +130,10 @@ describe('TransactionsService', () => {
 
       expect(mockAi.categorizeTransaction).not.toHaveBeenCalled();
       expect(mockPrisma.transaction.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({ category: 'Income', aiConfidence: null }),
+        data: expect.objectContaining({
+          category: 'Income',
+          aiConfidence: null,
+        }),
       });
     });
 

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -16,7 +16,10 @@ export class TransactionsService {
     private readonly ai: AiService,
   ) {}
 
-  async create(userId: string, dto: CreateTransactionDto): Promise<Transaction> {
+  async create(
+    userId: string,
+    dto: CreateTransactionDto,
+  ): Promise<Transaction> {
     let category = dto.category;
     let aiConfidence: number | null = null;
 
@@ -30,7 +33,7 @@ export class TransactionsService {
         category = result.category;
         aiConfidence = result.confidence;
       } catch {
-        category = 'Uncategorized';
+        category = 'Other';
       }
     }
 


### PR DESCRIPTION
## Summary
- Fixes TypeScript build error: `'Uncategorized'` is not a valid `TransactionCategory`
- Uses `'Other'` as the fallback category when AI categorization throws

Fixes the build failure from #41.