### PR TITLE
feat(ai): LangChain LCEL integration with multi-provider support and fallback chain

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -3,9 +3,15 @@ JWT_ACCESS_SECRET="change-me-access-secret"
 JWT_REFRESH_SECRET="change-me-refresh-secret"
 JWT_ACCESS_EXPIRY="15m"
 JWT_REFRESH_EXPIRY="7d"
-ANTHROPIC_API_KEY="sk-ant-..."
+AI_PROVIDER="anthropic"
 AI_MODEL="claude-opus-4-6"
+# --- Anthropic ---
+ANTHROPIC_API_KEY="sk-ant-..."
 AI_THINKING_BUDGET_TOKENS=8000
+# --- OpenAI ---
+# OPENAI_API_KEY=""
+# --- Groq ---
+# GROQ_API_KEY=""
 PORT=3000
 # Comma-separated allowed CORS origins (leave empty to allow all)
 ALLOWED_ORIGINS=""

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -12,6 +12,14 @@ AI_THINKING_BUDGET_TOKENS=8000
 # OPENAI_API_KEY=""
 # --- Groq ---
 # GROQ_API_KEY=""
+# --- Gemini ---
+# GOOGLE_API_KEY=""
 PORT=3000
+
+# LangSmith observability (https://smith.langchain.com)
+# Set LANGCHAIN_TRACING_V2=true and add your API key to enable
+LANGCHAIN_TRACING_V2=false
+# LANGCHAIN_API_KEY=""
+# LANGCHAIN_PROJECT="financial-advisor"
 # Comma-separated allowed CORS origins (leave empty to allow all)
 ALLOWED_ORIGINS=""

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,6 +4,8 @@ JWT_REFRESH_SECRET="change-me-refresh-secret"
 JWT_ACCESS_EXPIRY="15m"
 JWT_REFRESH_EXPIRY="7d"
 ANTHROPIC_API_KEY="sk-ant-..."
+AI_MODEL="claude-opus-4-6"
+AI_THINKING_BUDGET_TOKENS=8000
 PORT=3000
 # Comma-separated allowed CORS origins (leave empty to allow all)
 ALLOWED_ORIGINS=""

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -3,17 +3,21 @@ JWT_ACCESS_SECRET="change-me-access-secret"
 JWT_REFRESH_SECRET="change-me-refresh-secret"
 JWT_ACCESS_EXPIRY="15m"
 JWT_REFRESH_EXPIRY="7d"
-AI_PROVIDER="anthropic"
-AI_MODEL="claude-opus-4-6"
-# --- Anthropic ---
-ANTHROPIC_API_KEY="sk-ant-..."
-AI_THINKING_BUDGET_TOKENS=8000
+# Default: Gemini (free tier, good quality for dev + early prod)
+# Switch to "anthropic" + claude-opus-4-6 when ready for production scale
+AI_PROVIDER="gemini"
+AI_MODEL="gemini-2.0-flash"
+# --- Gemini ---
+GOOGLE_API_KEY=""
+# --- Anthropic (production) ---
+# AI_PROVIDER="anthropic"
+# AI_MODEL="claude-opus-4-6"
+# ANTHROPIC_API_KEY="sk-ant-..."
+# AI_THINKING_BUDGET_TOKENS=8000
 # --- OpenAI ---
 # OPENAI_API_KEY=""
 # --- Groq ---
 # GROQ_API_KEY=""
-# --- Gemini ---
-# GOOGLE_API_KEY=""
 PORT=3000
 
 # LangSmith observability (https://smith.langchain.com)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "@financial-advisor/shared": "*",
     "@langchain/anthropic": "^1.3.23",
     "@langchain/core": "^1.1.32",
+    "@langchain/google-genai": "^2.1.25",
     "@langchain/groq": "^1.1.5",
     "@langchain/openai": "^1.2.13",
     "@nestjs/common": "^11.0.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,8 @@
     "@financial-advisor/shared": "*",
     "@langchain/anthropic": "^1.3.23",
     "@langchain/core": "^1.1.32",
+    "@langchain/groq": "^1.1.5",
+    "@langchain/openai": "^1.2.13",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.0.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,8 +20,9 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.78.0",
     "@financial-advisor/shared": "*",
+    "@langchain/anthropic": "^1.3.23",
+    "@langchain/core": "^1.1.32",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.0.1",
@@ -34,6 +35,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "dotenv": "^17.3.1",
+    "langchain": "^1.2.32",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.20.0",

--- a/apps/api/src/ai/ai.service.spec.ts
+++ b/apps/api/src/ai/ai.service.spec.ts
@@ -115,58 +115,6 @@ describe('AiService', () => {
   });
 
   // -------------------------------------------------------------------------
-  // categorizeTransaction
-  // -------------------------------------------------------------------------
-
-  describe('categorizeTransaction', () => {
-    it('should return category and confidence from primary model', async () => {
-      const service = await buildService();
-      mockInvoke.mockResolvedValue({ category: 'Food', confidence: 0.92 });
-
-      const result = await service.categorizeTransaction(
-        'Grocery store',
-        50,
-        'EXPENSE',
-      );
-
-      expect(mockInvoke).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'EXPENSE',
-          categories: expect.any(String),
-        }),
-      );
-      expect(result).toEqual({ category: 'Food', confidence: 0.92 });
-    });
-
-    it('should use fallback model when primary fails', async () => {
-      const fallback = makeMockModel(() => mockFallbackInvoke);
-      const service = await buildService([fallback]);
-      mockInvoke.mockRejectedValue(new Error('API error'));
-      mockFallbackInvoke.mockResolvedValue({
-        category: 'Transport',
-        confidence: 0.7,
-      });
-
-      const result = await service.categorizeTransaction('Uber', 15, 'EXPENSE');
-
-      expect(result).toEqual({ category: 'Transport', confidence: 0.7 });
-    });
-
-    it('should return static fallback when all models fail', async () => {
-      const service = await buildService();
-      mockInvoke.mockRejectedValue(new Error('API error'));
-
-      const result = await service.categorizeTransaction(
-        'Unknown',
-        10,
-        'EXPENSE',
-      );
-
-      expect(result).toEqual({ category: 'Other', confidence: 0 });
-    });
-  });
-
-  // -------------------------------------------------------------------------
   // generateInsights
   // -------------------------------------------------------------------------
 

--- a/apps/api/src/ai/ai.service.spec.ts
+++ b/apps/api/src/ai/ai.service.spec.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { AiService } from './ai.service';
 import * as llmFactory from './llm.factory';
 import type { Transaction } from '@financial-advisor/shared';
@@ -10,39 +9,39 @@ import type { Transaction } from '@financial-advisor/shared';
 // ---------------------------------------------------------------------------
 
 let mockInvoke: jest.Mock;
+let mockFallbackInvoke: jest.Mock;
 
-// Mock the factory so ai.service.spec stays independent of provider logic
-jest.mock('./llm.factory', () => ({
-  createLlmPair: jest.fn().mockReturnValue({
-    model: {
-      withStructuredOutput: jest.fn().mockReturnValue({
-        invoke: (...args: unknown[]) => mockInvoke(...args),
-      }),
+/**
+ * Builds a mock model whose invoke routes through the provided spy.
+ * prompt.pipe(model) returns the model itself (see ChatPromptTemplate mock below),
+ * so model.pipe(parser).invoke() and model.withStructuredOutput().invoke() both
+ * call through to the spy.
+ */
+function makeMockModel(spy: () => jest.Mock) {
+  return {
+    withStructuredOutput: jest.fn().mockReturnValue({
+      invoke: (...args: unknown[]) => spy()(...args),
+    }),
+    pipe: jest.fn().mockReturnValue({
+      invoke: (...args: unknown[]) => spy()(...args),
       pipe: jest.fn().mockReturnValue({
-        pipe: jest.fn().mockReturnValue({
-          invoke: (...args: unknown[]) => mockInvoke(...args),
-        }),
+        invoke: (...args: unknown[]) => spy()(...args),
       }),
-    },
-    thinkingModel: {
-      pipe: jest.fn().mockReturnValue({
-        pipe: jest.fn().mockReturnValue({
-          invoke: (...args: unknown[]) => mockInvoke(...args),
-        }),
-      }),
-    },
-  }),
-}));
+    }),
+  };
+}
 
+jest.mock('./llm.factory', () => ({ createLlmPair: jest.fn() }));
+
+/**
+ * Make prompt.pipe(runnable) return the runnable directly so that
+ * prompt.pipe(model.withStructuredOutput(schema)) delegates to the correct
+ * model's invoke — primary or fallback.
+ */
 jest.mock('@langchain/core/prompts', () => ({
   ChatPromptTemplate: {
     fromTemplate: jest.fn().mockReturnValue({
-      pipe: jest.fn().mockReturnValue({
-        pipe: jest.fn().mockReturnValue({
-          invoke: (...args: unknown[]) => mockInvoke(...args),
-        }),
-        invoke: (...args: unknown[]) => mockInvoke(...args),
-      }),
+      pipe: jest.fn().mockImplementation((runnable: any) => runnable),
     }),
   },
 }));
@@ -51,9 +50,7 @@ jest.mock('@langchain/core/output_parsers', () => ({
   StringOutputParser: jest.fn().mockImplementation(() => ({})),
 }));
 
-const mockConfigService = {
-  getOrThrow: jest.fn(),
-} as unknown as ConfigService;
+const mockConfigService = { getOrThrow: jest.fn() } as unknown as ConfigService;
 
 const mockTransactions: Transaction[] = [
   {
@@ -80,32 +77,40 @@ const mockTransactions: Transaction[] = [
   },
 ];
 
+async function buildService(
+  fallbackModels: unknown[] = [],
+): Promise<AiService> {
+  (llmFactory.createLlmPair as jest.Mock).mockReturnValue({
+    model: makeMockModel(() => mockInvoke),
+    thinkingModel: makeMockModel(() => mockInvoke),
+    fallbackModels,
+  });
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      AiService,
+      { provide: ConfigService, useValue: mockConfigService },
+    ],
+  }).compile();
+  return module.get<AiService>(AiService);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe('AiService', () => {
-  let service: AiService;
-
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.clearAllMocks();
     mockInvoke = jest.fn();
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        AiService,
-        { provide: ConfigService, useValue: mockConfigService },
-      ],
-    }).compile();
-
-    service = module.get<AiService>(AiService);
+    mockFallbackInvoke = jest.fn();
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('should be defined', async () => {
+    expect(await buildService()).toBeDefined();
   });
 
-  it('should delegate model creation to createLlmPair', () => {
+  it('should delegate model creation to createLlmPair', async () => {
+    await buildService();
     expect(llmFactory.createLlmPair).toHaveBeenCalledWith(mockConfigService);
   });
 
@@ -114,9 +119,9 @@ describe('AiService', () => {
   // -------------------------------------------------------------------------
 
   describe('categorizeTransaction', () => {
-    it('should invoke the structured output chain and return category + confidence', async () => {
-      const mockResult = { category: 'Food', confidence: 0.92 };
-      mockInvoke.mockResolvedValue(mockResult);
+    it('should return category and confidence from primary model', async () => {
+      const service = await buildService();
+      mockInvoke.mockResolvedValue({ category: 'Food', confidence: 0.92 });
 
       const result = await service.categorizeTransaction(
         'Grocery store',
@@ -126,12 +131,38 @@ describe('AiService', () => {
 
       expect(mockInvoke).toHaveBeenCalledWith(
         expect.objectContaining({
-          description: expect.any(String),
           type: 'EXPENSE',
           categories: expect.any(String),
         }),
       );
-      expect(result).toEqual(mockResult);
+      expect(result).toEqual({ category: 'Food', confidence: 0.92 });
+    });
+
+    it('should use fallback model when primary fails', async () => {
+      const fallback = makeMockModel(() => mockFallbackInvoke);
+      const service = await buildService([fallback]);
+      mockInvoke.mockRejectedValue(new Error('API error'));
+      mockFallbackInvoke.mockResolvedValue({
+        category: 'Transport',
+        confidence: 0.7,
+      });
+
+      const result = await service.categorizeTransaction('Uber', 15, 'EXPENSE');
+
+      expect(result).toEqual({ category: 'Transport', confidence: 0.7 });
+    });
+
+    it('should return static fallback when all models fail', async () => {
+      const service = await buildService();
+      mockInvoke.mockRejectedValue(new Error('API error'));
+
+      const result = await service.categorizeTransaction(
+        'Unknown',
+        10,
+        'EXPENSE',
+      );
+
+      expect(result).toEqual({ category: 'Other', confidence: 0 });
     });
   });
 
@@ -141,6 +172,7 @@ describe('AiService', () => {
 
   describe('generateInsights', () => {
     it('should invoke the text chain and return plain text', async () => {
+      const service = await buildService();
       mockInvoke.mockResolvedValue('You spend too much on food.');
 
       const result = await service.generateInsights(mockTransactions, 'weekly');
@@ -155,6 +187,7 @@ describe('AiService', () => {
     });
 
     it('should pass "No transactions available." in summary for empty list', async () => {
+      const service = await buildService();
       mockInvoke.mockResolvedValue('No data available.');
 
       await service.generateInsights([], 'monthly');
@@ -162,6 +195,26 @@ describe('AiService', () => {
       expect(mockInvoke).toHaveBeenCalledWith(
         expect.objectContaining({ summary: 'No transactions available.' }),
       );
+    });
+
+    it('should use fallback model when primary fails', async () => {
+      const fallback = makeMockModel(() => mockFallbackInvoke);
+      const service = await buildService([fallback]);
+      mockInvoke.mockRejectedValue(new Error('API error'));
+      mockFallbackInvoke.mockResolvedValue('Fallback insight.');
+
+      const result = await service.generateInsights(mockTransactions, 'weekly');
+
+      expect(result).toBe('Fallback insight.');
+    });
+
+    it('should return static fallback when all models fail', async () => {
+      const service = await buildService();
+      mockInvoke.mockRejectedValue(new Error('API error'));
+
+      const result = await service.generateInsights([], 'weekly');
+
+      expect(result).toMatch(/temporarily unavailable/i);
     });
   });
 
@@ -171,23 +224,23 @@ describe('AiService', () => {
 
   describe('generateGoalRecommendation', () => {
     it('should invoke chain and return recommendation text', async () => {
+      const service = await buildService();
       mockInvoke.mockResolvedValue('Cut dining out by 20%.');
 
-      const goal = {
-        description: 'Save for vacation',
-        targetAmount: 2000,
-        deadline: '2025-12-31',
-      };
       const result = await service.generateGoalRecommendation(
-        goal,
+        {
+          description: 'Save for vacation',
+          targetAmount: 2000,
+          deadline: '2025-12-31',
+        },
         mockTransactions,
       );
 
-      expect(mockInvoke).toHaveBeenCalled();
       expect(result).toBe('Cut dining out by 20%.');
     });
 
     it('should pass empty deadlineLine when deadline is not provided', async () => {
+      const service = await buildService();
       mockInvoke.mockResolvedValue('Advice.');
 
       await service.generateGoalRecommendation(
@@ -201,6 +254,7 @@ describe('AiService', () => {
     });
 
     it('should pass deadlineLine when deadline is provided', async () => {
+      const service = await buildService();
       mockInvoke.mockResolvedValue('Advice.');
 
       // deadline is truncated to YYYY-MM by the anonymizer
@@ -217,6 +271,18 @@ describe('AiService', () => {
         expect.objectContaining({ deadlineLine: 'Deadline: 2025-06' }),
       );
     });
+
+    it('should return static fallback when all models fail', async () => {
+      const service = await buildService();
+      mockInvoke.mockRejectedValue(new Error('API error'));
+
+      const result = await service.generateGoalRecommendation(
+        { description: 'savings goal', targetAmount: 500 },
+        [],
+      );
+
+      expect(result).toMatch(/temporarily unavailable/i);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -225,29 +291,44 @@ describe('AiService', () => {
 
   describe('generateWeeklyChallenge', () => {
     it('should invoke chain and return challenge text', async () => {
+      const service = await buildService();
       mockInvoke.mockResolvedValue('Spend less than $60 on Food this week.');
 
-      const weekStart = new Date('2025-01-06');
-      const weekEnd = new Date('2025-01-12');
       const result = await service.generateWeeklyChallenge(
         mockTransactions,
-        weekStart,
-        weekEnd,
+        new Date('2025-01-06'),
+        new Date('2025-01-12'),
       );
 
       expect(result).toBe('Spend less than $60 on Food this week.');
     });
 
     it('should include date range in chain invocation', async () => {
+      const service = await buildService();
       mockInvoke.mockResolvedValue('Save at least $50.');
 
-      const weekStart = new Date('2025-03-10');
-      const weekEnd = new Date('2025-03-16');
-      await service.generateWeeklyChallenge([], weekStart, weekEnd);
+      await service.generateWeeklyChallenge(
+        [],
+        new Date('2025-03-10'),
+        new Date('2025-03-16'),
+      );
 
       expect(mockInvoke).toHaveBeenCalledWith(
         expect.objectContaining({ from: '2025-03-10', to: '2025-03-16' }),
       );
+    });
+
+    it('should return static fallback when all models fail', async () => {
+      const service = await buildService();
+      mockInvoke.mockRejectedValue(new Error('API error'));
+
+      const result = await service.generateWeeklyChallenge(
+        [],
+        new Date('2025-01-06'),
+        new Date('2025-01-12'),
+      );
+
+      expect(result).toMatch(/save at least \$10/i);
     });
   });
 });

--- a/apps/api/src/ai/ai.service.spec.ts
+++ b/apps/api/src/ai/ai.service.spec.ts
@@ -1,28 +1,37 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import { ChatAnthropic } from '@langchain/anthropic';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { AiService } from './ai.service';
+import * as llmFactory from './llm.factory';
 import type { Transaction } from '@financial-advisor/shared';
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
-// Shared invoke spy — assigned in beforeEach so it can be controlled per-test
 let mockInvoke: jest.Mock;
 
-jest.mock('@langchain/anthropic', () => ({
-  ChatAnthropic: jest.fn().mockImplementation(() => ({
-    withStructuredOutput: jest.fn().mockReturnValue({
-      invoke: (...args: unknown[]) => mockInvoke(...args),
-    }),
-    pipe: jest.fn().mockReturnValue({
-      pipe: jest.fn().mockReturnValue({
+// Mock the factory so ai.service.spec stays independent of provider logic
+jest.mock('./llm.factory', () => ({
+  createLlmPair: jest.fn().mockReturnValue({
+    model: {
+      withStructuredOutput: jest.fn().mockReturnValue({
         invoke: (...args: unknown[]) => mockInvoke(...args),
       }),
-    }),
-  })),
+      pipe: jest.fn().mockReturnValue({
+        pipe: jest.fn().mockReturnValue({
+          invoke: (...args: unknown[]) => mockInvoke(...args),
+        }),
+      }),
+    },
+    thinkingModel: {
+      pipe: jest.fn().mockReturnValue({
+        pipe: jest.fn().mockReturnValue({
+          invoke: (...args: unknown[]) => mockInvoke(...args),
+        }),
+      }),
+    },
+  }),
 }));
 
 jest.mock('@langchain/core/prompts', () => ({
@@ -43,14 +52,7 @@ jest.mock('@langchain/core/output_parsers', () => ({
 }));
 
 const mockConfigService = {
-  getOrThrow: jest.fn().mockImplementation((key: string) => {
-    const values: Record<string, string | number> = {
-      ANTHROPIC_API_KEY: 'test-api-key',
-      AI_MODEL: 'claude-opus-4-6',
-      AI_THINKING_BUDGET_TOKENS: 8000,
-    };
-    return values[key];
-  }),
+  getOrThrow: jest.fn(),
 } as unknown as ConfigService;
 
 const mockTransactions: Transaction[] = [
@@ -103,31 +105,8 @@ describe('AiService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should read AI config from env vars', () => {
-    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
-      'ANTHROPIC_API_KEY',
-    );
-    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith('AI_MODEL');
-    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
-      'AI_THINKING_BUDGET_TOKENS',
-    );
-  });
-
-  it('should initialise standard model from env vars', () => {
-    expect(ChatAnthropic).toHaveBeenCalledWith(
-      expect.objectContaining({
-        apiKey: 'test-api-key',
-        model: 'claude-opus-4-6',
-      }),
-    );
-  });
-
-  it('should initialise thinking model with budget from env var', () => {
-    expect(ChatAnthropic).toHaveBeenCalledWith(
-      expect.objectContaining({
-        thinking: { type: 'enabled', budget_tokens: 8000 },
-      }),
-    );
+  it('should delegate model creation to createLlmPair', () => {
+    expect(llmFactory.createLlmPair).toHaveBeenCalledWith(mockConfigService);
   });
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/ai/ai.service.spec.ts
+++ b/apps/api/src/ai/ai.service.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import Anthropic from '@anthropic-ai/sdk';
+import { ChatAnthropic } from '@langchain/anthropic';
+import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { AiService } from './ai.service';
 import type { Transaction } from '@financial-advisor/shared';
 
@@ -8,9 +9,37 @@ import type { Transaction } from '@financial-advisor/shared';
 // Mocks
 // ---------------------------------------------------------------------------
 
-jest.mock('@anthropic-ai/sdk');
-jest.mock('@anthropic-ai/sdk/helpers/zod', () => ({
-  zodOutputFormat: jest.fn().mockReturnValue({ type: 'json_schema' }),
+// Shared invoke spy — assigned in beforeEach so it can be controlled per-test
+let mockInvoke: jest.Mock;
+
+jest.mock('@langchain/anthropic', () => ({
+  ChatAnthropic: jest.fn().mockImplementation(() => ({
+    withStructuredOutput: jest.fn().mockReturnValue({
+      invoke: (...args: unknown[]) => mockInvoke(...args),
+    }),
+    pipe: jest.fn().mockReturnValue({
+      pipe: jest.fn().mockReturnValue({
+        invoke: (...args: unknown[]) => mockInvoke(...args),
+      }),
+    }),
+  })),
+}));
+
+jest.mock('@langchain/core/prompts', () => ({
+  ChatPromptTemplate: {
+    fromTemplate: jest.fn().mockReturnValue({
+      pipe: jest.fn().mockReturnValue({
+        pipe: jest.fn().mockReturnValue({
+          invoke: (...args: unknown[]) => mockInvoke(...args),
+        }),
+        invoke: (...args: unknown[]) => mockInvoke(...args),
+      }),
+    }),
+  },
+}));
+
+jest.mock('@langchain/core/output_parsers', () => ({
+  StringOutputParser: jest.fn().mockImplementation(() => ({})),
 }));
 
 const mockConfigService = {
@@ -48,10 +77,10 @@ const mockTransactions: Transaction[] = [
 
 describe('AiService', () => {
   let service: AiService;
-  let mockClient: jest.Mocked<Anthropic>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockInvoke = jest.fn();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -61,19 +90,30 @@ describe('AiService', () => {
     }).compile();
 
     service = module.get<AiService>(AiService);
-    mockClient = (Anthropic as jest.MockedClass<typeof Anthropic>).mock
-      .instances[0] as jest.Mocked<Anthropic>;
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
 
-  it('should initialise Anthropic client with ANTHROPIC_API_KEY', () => {
+  it('should initialise ChatAnthropic with ANTHROPIC_API_KEY', () => {
     expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
       'ANTHROPIC_API_KEY',
     );
-    expect(Anthropic).toHaveBeenCalledWith({ apiKey: 'test-api-key' });
+    expect(ChatAnthropic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'test-api-key',
+        model: 'claude-opus-4-6',
+      }),
+    );
+  });
+
+  it('should create a thinking model with extended thinking enabled', () => {
+    expect(ChatAnthropic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thinking: { type: 'enabled', budget_tokens: 8000 },
+      }),
+    );
   });
 
   // -------------------------------------------------------------------------
@@ -81,11 +121,9 @@ describe('AiService', () => {
   // -------------------------------------------------------------------------
 
   describe('categorizeTransaction', () => {
-    it('should call messages.parse and return category + confidence', async () => {
-      const mockParsed = { category: 'Food', confidence: 0.92 };
-      (mockClient.messages as any) = {
-        parse: jest.fn().mockResolvedValue({ parsed_output: mockParsed }),
-      };
+    it('should invoke the structured output chain and return category + confidence', async () => {
+      const mockResult = { category: 'Food', confidence: 0.92 };
+      mockInvoke.mockResolvedValue(mockResult);
 
       const result = await service.categorizeTransaction(
         'Grocery store',
@@ -93,16 +131,14 @@ describe('AiService', () => {
         'EXPENSE',
       );
 
-      expect(mockClient.messages.parse).toHaveBeenCalledWith(
+      expect(mockInvoke).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'claude-opus-4-6',
-          max_tokens: 256,
-          messages: expect.arrayContaining([
-            expect.objectContaining({ role: 'user' }),
-          ]),
+          description: expect.any(String),
+          type: 'EXPENSE',
+          categories: expect.any(String),
         }),
       );
-      expect(result).toEqual(mockParsed);
+      expect(result).toEqual(mockResult);
     });
   });
 
@@ -111,50 +147,28 @@ describe('AiService', () => {
   // -------------------------------------------------------------------------
 
   describe('generateInsights', () => {
-    it('should stream insights and return plain text', async () => {
-      const mockContent: Anthropic.ContentBlock[] = [
-        { type: 'text', text: 'You spend too much on food.' },
-      ];
-      const mockStream = {
-        finalMessage: jest
-          .fn()
-          .mockResolvedValue({ content: mockContent, stop_reason: 'end_turn' }),
-      };
-      (mockClient.messages as any) = {
-        stream: jest.fn().mockReturnValue(mockStream),
-      };
+    it('should invoke the text chain and return plain text', async () => {
+      mockInvoke.mockResolvedValue('You spend too much on food.');
 
       const result = await service.generateInsights(mockTransactions, 'weekly');
 
-      expect(mockClient.messages.stream).toHaveBeenCalledWith(
+      expect(mockInvoke).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'claude-opus-4-6',
-          thinking: { type: 'adaptive' },
-          messages: expect.arrayContaining([
-            expect.objectContaining({ role: 'user' }),
-          ]),
+          period: 'weekly',
+          summary: expect.any(String),
         }),
       );
       expect(result).toBe('You spend too much on food.');
     });
 
-    it('should handle empty transactions', async () => {
-      const mockStream = {
-        finalMessage: jest.fn().mockResolvedValue({
-          content: [{ type: 'text', text: 'No data available.' }],
-          stop_reason: 'end_turn',
-        }),
-      };
-      (mockClient.messages as any) = {
-        stream: jest.fn().mockReturnValue(mockStream),
-      };
+    it('should pass "No transactions available." in summary for empty list', async () => {
+      mockInvoke.mockResolvedValue('No data available.');
 
-      const result = await service.generateInsights([], 'monthly');
+      await service.generateInsights([], 'monthly');
 
-      const userMessage = (mockClient.messages.stream as jest.Mock).mock
-        .calls[0][0].messages[0].content as string;
-      expect(userMessage).toContain('No transactions available.');
-      expect(result).toBe('No data available.');
+      expect(mockInvoke).toHaveBeenCalledWith(
+        expect.objectContaining({ summary: 'No transactions available.' }),
+      );
     });
   });
 
@@ -163,16 +177,8 @@ describe('AiService', () => {
   // -------------------------------------------------------------------------
 
   describe('generateGoalRecommendation', () => {
-    it('should stream a goal recommendation', async () => {
-      const mockStream = {
-        finalMessage: jest.fn().mockResolvedValue({
-          content: [{ type: 'text', text: 'Cut dining out by 20%.' }],
-          stop_reason: 'end_turn',
-        }),
-      };
-      (mockClient.messages as any) = {
-        stream: jest.fn().mockReturnValue(mockStream),
-      };
+    it('should invoke chain and return recommendation text', async () => {
+      mockInvoke.mockResolvedValue('Cut dining out by 20%.');
 
       const goal = {
         description: 'Save for vacation',
@@ -184,34 +190,39 @@ describe('AiService', () => {
         mockTransactions,
       );
 
-      expect(mockClient.messages.stream).toHaveBeenCalledWith(
-        expect.objectContaining({
-          model: 'claude-opus-4-6',
-          thinking: { type: 'adaptive' },
-        }),
-      );
+      expect(mockInvoke).toHaveBeenCalled();
       expect(result).toBe('Cut dining out by 20%.');
     });
 
-    it('should omit deadline line when not provided', async () => {
-      const mockStream = {
-        finalMessage: jest.fn().mockResolvedValue({
-          content: [{ type: 'text', text: 'Advice.' }],
-          stop_reason: 'end_turn',
-        }),
-      };
-      (mockClient.messages as any) = {
-        stream: jest.fn().mockReturnValue(mockStream),
-      };
+    it('should pass empty deadlineLine when deadline is not provided', async () => {
+      mockInvoke.mockResolvedValue('Advice.');
 
       await service.generateGoalRecommendation(
         { description: 'Emergency fund', targetAmount: 1000 },
         [],
       );
 
-      const prompt = (mockClient.messages.stream as jest.Mock).mock.calls[0][0]
-        .messages[0].content as string;
-      expect(prompt).not.toContain('Deadline:');
+      expect(mockInvoke).toHaveBeenCalledWith(
+        expect.objectContaining({ deadlineLine: '' }),
+      );
+    });
+
+    it('should pass deadlineLine when deadline is provided', async () => {
+      mockInvoke.mockResolvedValue('Advice.');
+
+      // deadline is truncated to YYYY-MM by the anonymizer
+      await service.generateGoalRecommendation(
+        {
+          description: 'savings goal',
+          targetAmount: 1000,
+          deadline: '2025-06-01',
+        },
+        [],
+      );
+
+      expect(mockInvoke).toHaveBeenCalledWith(
+        expect.objectContaining({ deadlineLine: 'Deadline: 2025-06' }),
+      );
     });
   });
 
@@ -220,15 +231,8 @@ describe('AiService', () => {
   // -------------------------------------------------------------------------
 
   describe('generateWeeklyChallenge', () => {
-    it('should call messages.create and return challenge text', async () => {
-      (mockClient.messages as any) = {
-        create: jest.fn().mockResolvedValue({
-          content: [
-            { type: 'text', text: 'Spend less than $60 on Food this week.' },
-          ],
-          stop_reason: 'end_turn',
-        }),
-      };
+    it('should invoke chain and return challenge text', async () => {
+      mockInvoke.mockResolvedValue('Spend less than $60 on Food this week.');
 
       const weekStart = new Date('2025-01-06');
       const weekEnd = new Date('2025-01-12');
@@ -238,34 +242,19 @@ describe('AiService', () => {
         weekEnd,
       );
 
-      expect(mockClient.messages.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          model: 'claude-opus-4-6',
-          max_tokens: 256,
-          messages: expect.arrayContaining([
-            expect.objectContaining({ role: 'user' }),
-          ]),
-        }),
-      );
       expect(result).toBe('Spend less than $60 on Food this week.');
     });
 
-    it('should include date range in the prompt', async () => {
-      (mockClient.messages as any) = {
-        create: jest.fn().mockResolvedValue({
-          content: [{ type: 'text', text: 'Save at least $50.' }],
-          stop_reason: 'end_turn',
-        }),
-      };
+    it('should include date range in chain invocation', async () => {
+      mockInvoke.mockResolvedValue('Save at least $50.');
 
       const weekStart = new Date('2025-03-10');
       const weekEnd = new Date('2025-03-16');
       await service.generateWeeklyChallenge([], weekStart, weekEnd);
 
-      const prompt = (mockClient.messages.create as jest.Mock).mock.calls[0][0]
-        .messages[0].content as string;
-      expect(prompt).toContain('2025-03-10');
-      expect(prompt).toContain('2025-03-16');
+      expect(mockInvoke).toHaveBeenCalledWith(
+        expect.objectContaining({ from: '2025-03-10', to: '2025-03-16' }),
+      );
     });
   });
 });

--- a/apps/api/src/ai/ai.service.spec.ts
+++ b/apps/api/src/ai/ai.service.spec.ts
@@ -43,7 +43,14 @@ jest.mock('@langchain/core/output_parsers', () => ({
 }));
 
 const mockConfigService = {
-  getOrThrow: jest.fn().mockReturnValue('test-api-key'),
+  getOrThrow: jest.fn().mockImplementation((key: string) => {
+    const values: Record<string, string | number> = {
+      ANTHROPIC_API_KEY: 'test-api-key',
+      AI_MODEL: 'claude-opus-4-6',
+      AI_THINKING_BUDGET_TOKENS: 8000,
+    };
+    return values[key];
+  }),
 } as unknown as ConfigService;
 
 const mockTransactions: Transaction[] = [
@@ -96,10 +103,17 @@ describe('AiService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should initialise ChatAnthropic with ANTHROPIC_API_KEY', () => {
+  it('should read AI config from env vars', () => {
     expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
       'ANTHROPIC_API_KEY',
     );
+    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith('AI_MODEL');
+    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
+      'AI_THINKING_BUDGET_TOKENS',
+    );
+  });
+
+  it('should initialise standard model from env vars', () => {
     expect(ChatAnthropic).toHaveBeenCalledWith(
       expect.objectContaining({
         apiKey: 'test-api-key',
@@ -108,7 +122,7 @@ describe('AiService', () => {
     );
   });
 
-  it('should create a thinking model with extended thinking enabled', () => {
+  it('should initialise thinking model with budget from env var', () => {
     expect(ChatAnthropic).toHaveBeenCalledWith(
       expect.objectContaining({
         thinking: { type: 'enabled', budget_tokens: 8000 },

--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ChatAnthropic } from '@langchain/anthropic';
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { StringOutputParser } from '@langchain/core/output_parsers';
 import { z } from 'zod';
+import { createLlmPair } from './llm.factory';
 import type {
   CreateGoalDto,
   InsightPeriod,
@@ -39,19 +40,13 @@ type Categorization = z.infer<typeof CategorizationSchema>;
 
 @Injectable()
 export class AiService {
-  private readonly model: ChatAnthropic;
-  private readonly thinkingModel: ChatAnthropic;
+  private readonly model: BaseChatModel;
+  private readonly thinkingModel: BaseChatModel;
 
   constructor(config: ConfigService) {
-    const apiKey = config.getOrThrow<string>('ANTHROPIC_API_KEY');
-    const model = config.getOrThrow<string>('AI_MODEL');
-    const budgetTokens = config.getOrThrow<number>('AI_THINKING_BUDGET_TOKENS');
-    this.model = new ChatAnthropic({ apiKey, model });
-    this.thinkingModel = new ChatAnthropic({
-      apiKey,
-      model,
-      thinking: { type: 'enabled', budget_tokens: budgetTokens },
-    });
+    const { model, thinkingModel } = createLlmPair(config);
+    this.model = model;
+    this.thinkingModel = thinkingModel;
   }
 
   async categorizeTransaction(

--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import Anthropic from '@anthropic-ai/sdk';
-import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import { ChatAnthropic } from '@langchain/anthropic';
+import { ChatPromptTemplate } from '@langchain/core/prompts';
+import { StringOutputParser } from '@langchain/core/output_parsers';
 import { z } from 'zod';
 import type {
   CreateGoalDto,
@@ -38,12 +39,19 @@ type Categorization = z.infer<typeof CategorizationSchema>;
 
 @Injectable()
 export class AiService {
-  private readonly client: Anthropic;
-  private readonly model = 'claude-opus-4-6';
+  private readonly model: ChatAnthropic;
+  private readonly thinkingModel: ChatAnthropic;
 
   constructor(config: ConfigService) {
-    this.client = new Anthropic({
-      apiKey: config.getOrThrow<string>('ANTHROPIC_API_KEY'),
+    const apiKey = config.getOrThrow<string>('ANTHROPIC_API_KEY');
+    this.model = new ChatAnthropic({
+      apiKey,
+      model: 'claude-opus-4-6',
+    });
+    this.thinkingModel = new ChatAnthropic({
+      apiKey,
+      model: 'claude-opus-4-6',
+      thinking: { type: 'enabled', budget_tokens: 8000 },
     });
   }
 
@@ -53,27 +61,24 @@ export class AiService {
     type: TransactionType,
   ): Promise<Categorization> {
     const safeDescription = scrubDescription(description);
-    const response = await this.client.messages.parse({
-      model: this.model,
-      max_tokens: 256,
-      messages: [
-        {
-          role: 'user',
-          content: `Categorize this transaction:
-Description: ${safeDescription}
+    const prompt = ChatPromptTemplate.fromTemplate(
+      `Categorize this transaction:
+Description: {description}
 Amount: $${amount}
-Type: ${type}
+Type: {type}
 
-Choose from: ${TRANSACTION_CATEGORIES.join(', ')}.
+Choose from: {categories}.
 Return a confidence score between 0 and 1.`,
-        },
-      ],
-      output_config: {
-        format: zodOutputFormat(CategorizationSchema),
-      },
-    });
+    );
 
-    return response.parsed_output!;
+    const chain = prompt.pipe(
+      this.model.withStructuredOutput(CategorizationSchema),
+    );
+    return chain.invoke({
+      description: safeDescription,
+      type,
+      categories: TRANSACTION_CATEGORIES.join(', '),
+    });
   }
 
   async generateInsights(
@@ -81,23 +86,17 @@ Return a confidence score between 0 and 1.`,
     period: InsightPeriod,
   ): Promise<string> {
     const safeTxs = anonTransactions(transactions);
-    const stream = this.client.messages.stream({
-      model: this.model,
-      max_tokens: 1024,
-      thinking: { type: 'adaptive' },
-      messages: [
-        {
-          role: 'user',
-          content: `You are a personal finance advisor. Analyze the following ${period} transactions and provide 2-3 actionable insights in under 200 words.
+    const prompt = ChatPromptTemplate.fromTemplate(
+      `You are a personal finance advisor. Analyze the following {period} transactions and provide 2-3 actionable insights in under 200 words.
 
 Transaction summary:
-${buildTransactionSummary(safeTxs)}`,
-        },
-      ],
-    });
+{summary}`,
+    );
 
-    const message = await stream.finalMessage();
-    return extractText(message.content);
+    const chain = prompt
+      .pipe(this.thinkingModel)
+      .pipe(new StringOutputParser());
+    return chain.invoke({ period, summary: buildTransactionSummary(safeTxs) });
   }
 
   async generateGoalRecommendation(
@@ -110,27 +109,25 @@ ${buildTransactionSummary(safeTxs)}`,
       ? `Deadline: ${safeGoal.deadline}`
       : '';
 
-    const stream = this.client.messages.stream({
-      model: this.model,
-      max_tokens: 512,
-      thinking: { type: 'adaptive' },
-      messages: [
-        {
-          role: 'user',
-          content: `You are a personal finance advisor. Given this savings goal and recent spending, provide a concrete recommendation in 2-3 sentences.
+    const prompt = ChatPromptTemplate.fromTemplate(
+      `You are a personal finance advisor. Given this savings goal and recent spending, provide a concrete recommendation in 2-3 sentences.
 
-Goal: ${safeGoal.description}
-Target: $${safeGoal.targetAmount}
-${deadlineLine}
+Goal: {goalDescription}
+Target: ${safeGoal.targetAmount}
+{deadlineLine}
 
 Recent spending:
-${buildTransactionSummary(safeTxs)}`,
-        },
-      ],
-    });
+{summary}`,
+    );
 
-    const message = await stream.finalMessage();
-    return extractText(message.content);
+    const chain = prompt
+      .pipe(this.thinkingModel)
+      .pipe(new StringOutputParser());
+    return chain.invoke({
+      goalDescription: safeGoal.description,
+      deadlineLine,
+      summary: buildTransactionSummary(safeTxs),
+    });
   }
 
   async generateWeeklyChallenge(
@@ -142,23 +139,21 @@ ${buildTransactionSummary(safeTxs)}`,
     const from = weekStart.toISOString().split('T')[0];
     const to = weekEnd.toISOString().split('T')[0];
 
-    const response = await this.client.messages.create({
-      model: this.model,
-      max_tokens: 256,
-      messages: [
-        {
-          role: 'user',
-          content: `You are a personal finance coach. Based on this user's recent spending, generate one specific, achievable weekly challenge for ${from} to ${to}.
+    const prompt = ChatPromptTemplate.fromTemplate(
+      `You are a personal finance coach. Based on this user's recent spending, generate one specific, achievable weekly challenge for {from} to {to}.
 
 Recent spending:
-${buildTransactionSummary(safeTxs)}
+{summary}
 
 Return exactly one sentence starting with "Spend less than", "Save at least", or "Limit your". Use specific dollar amounts from the data.`,
-        },
-      ],
-    });
+    );
 
-    return extractText(response.content);
+    const chain = prompt.pipe(this.model).pipe(new StringOutputParser());
+    return chain.invoke({
+      from,
+      to,
+      summary: buildTransactionSummary(safeTxs),
+    });
   }
 }
 
@@ -184,11 +179,4 @@ function buildTransactionSummary(transactions: AnonTransaction[]): string {
         `- ${cat}: $${total.toFixed(2)} (${count} tx)`,
     )
     .join('\n');
-}
-
-function extractText(content: Anthropic.ContentBlock[]): string {
-  return content
-    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
-    .map((b) => b.text)
-    .join('');
 }

--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -44,14 +44,13 @@ export class AiService {
 
   constructor(config: ConfigService) {
     const apiKey = config.getOrThrow<string>('ANTHROPIC_API_KEY');
-    this.model = new ChatAnthropic({
-      apiKey,
-      model: 'claude-opus-4-6',
-    });
+    const model = config.getOrThrow<string>('AI_MODEL');
+    const budgetTokens = config.getOrThrow<number>('AI_THINKING_BUDGET_TOKENS');
+    this.model = new ChatAnthropic({ apiKey, model });
     this.thinkingModel = new ChatAnthropic({
       apiKey,
-      model: 'claude-opus-4-6',
-      thinking: { type: 'enabled', budget_tokens: 8000 },
+      model,
+      thinking: { type: 'enabled', budget_tokens: budgetTokens },
     });
   }
 

--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -1,51 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { StringOutputParser } from '@langchain/core/output_parsers';
-import { z } from 'zod';
 import { createLlmPair } from './llm.factory';
 import type {
   CreateGoalDto,
   InsightPeriod,
   Transaction,
-  TransactionCategory,
-  TransactionType,
 } from '@financial-advisor/shared';
-import {
-  anonGoal,
-  anonTransactions,
-  scrubDescription,
-  type AnonTransaction,
-} from './anonymizer';
-
-const TRANSACTION_CATEGORIES: [TransactionCategory, ...TransactionCategory[]] =
-  [
-    'Food',
-    'Transport',
-    'Bills',
-    'Entertainment',
-    'Shopping',
-    'Health',
-    'Income',
-    'Other',
-  ];
-
-const CategorizationSchema = z.object({
-  category: z.enum(TRANSACTION_CATEGORIES),
-  confidence: z.number().min(0).max(1),
-});
-
-type Categorization = z.infer<typeof CategorizationSchema>;
+import { anonGoal, anonTransactions, type AnonTransaction } from './anonymizer';
 
 const STATIC_FALLBACKS = {
-  categorization: { category: 'Other' as TransactionCategory, confidence: 0 },
   text: 'Our AI advisor is temporarily unavailable. Please try again shortly.',
   challenge: 'Save at least $10 this week as a starting point.',
 } as const;
 
 @Injectable()
 export class AiService {
+  private readonly logger = new Logger(AiService.name);
   private readonly model: BaseChatModel;
   private readonly thinkingModel: BaseChatModel;
   private readonly fallbackModels: BaseChatModel[];
@@ -55,42 +28,6 @@ export class AiService {
     this.model = model;
     this.thinkingModel = thinkingModel;
     this.fallbackModels = fallbackModels;
-  }
-
-  async categorizeTransaction(
-    description: string,
-    amount: number,
-    type: TransactionType,
-  ): Promise<Categorization> {
-    const safeDescription = scrubDescription(description);
-    const prompt = ChatPromptTemplate.fromTemplate(
-      `Categorize this transaction:
-Description: {description}
-Amount: $${amount}
-Type: {type}
-
-Choose from: {categories}.
-Return a confidence score between 0 and 1.`,
-    );
-    const vars = {
-      description: safeDescription,
-      type,
-      categories: TRANSACTION_CATEGORIES.join(', '),
-    };
-
-    return invokeWithFallbacks(
-      () =>
-        prompt
-          .pipe(this.model.withStructuredOutput(CategorizationSchema))
-          .invoke(vars),
-      this.fallbackModels.map(
-        (f) => () =>
-          prompt
-            .pipe(f.withStructuredOutput(CategorizationSchema))
-            .invoke(vars),
-      ),
-      STATIC_FALLBACKS.categorization,
-    );
   }
 
   async generateInsights(
@@ -113,6 +50,8 @@ Transaction summary:
         (f) => () => prompt.pipe(f).pipe(parser).invoke(vars),
       ),
       STATIC_FALLBACKS.text,
+      this.logger,
+      'generateInsights',
     );
   }
 
@@ -149,6 +88,8 @@ Recent spending:
         (f) => () => prompt.pipe(f).pipe(parser).invoke(vars),
       ),
       STATIC_FALLBACKS.text,
+      this.logger,
+      'generateGoalRecommendation',
     );
   }
 
@@ -178,6 +119,8 @@ Return exactly one sentence starting with "Spend less than", "Save at least", or
         (f) => () => prompt.pipe(f).pipe(parser).invoke(vars),
       ),
       STATIC_FALLBACKS.challenge,
+      this.logger,
+      'generateWeeklyChallenge',
     );
   }
 }
@@ -190,17 +133,27 @@ async function invokeWithFallbacks<T>(
   primaryFn: () => Promise<T>,
   fallbackFns: Array<() => Promise<T>>,
   staticFallback: T,
+  logger: Logger,
+  method: string,
 ): Promise<T> {
   try {
     return await primaryFn();
-  } catch {
+  } catch (err) {
+    logger.warn(
+      `[${method}] primary failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
     for (const fn of fallbackFns) {
       try {
         return await fn();
-      } catch {
-        continue;
+      } catch (fbErr) {
+        logger.warn(
+          `[${method}] fallback failed: ${fbErr instanceof Error ? fbErr.message : String(fbErr)}`,
+        );
       }
     }
+    logger.error(
+      `[${method}] all providers failed — returning static fallback`,
+    );
     return staticFallback;
   }
 }

--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -38,15 +38,23 @@ const CategorizationSchema = z.object({
 
 type Categorization = z.infer<typeof CategorizationSchema>;
 
+const STATIC_FALLBACKS = {
+  categorization: { category: 'Other' as TransactionCategory, confidence: 0 },
+  text: 'Our AI advisor is temporarily unavailable. Please try again shortly.',
+  challenge: 'Save at least $10 this week as a starting point.',
+} as const;
+
 @Injectable()
 export class AiService {
   private readonly model: BaseChatModel;
   private readonly thinkingModel: BaseChatModel;
+  private readonly fallbackModels: BaseChatModel[];
 
   constructor(config: ConfigService) {
-    const { model, thinkingModel } = createLlmPair(config);
+    const { model, thinkingModel, fallbackModels } = createLlmPair(config);
     this.model = model;
     this.thinkingModel = thinkingModel;
+    this.fallbackModels = fallbackModels;
   }
 
   async categorizeTransaction(
@@ -64,15 +72,25 @@ Type: {type}
 Choose from: {categories}.
 Return a confidence score between 0 and 1.`,
     );
-
-    const chain = prompt.pipe(
-      this.model.withStructuredOutput(CategorizationSchema),
-    );
-    return chain.invoke({
+    const vars = {
       description: safeDescription,
       type,
       categories: TRANSACTION_CATEGORIES.join(', '),
-    });
+    };
+
+    return invokeWithFallbacks(
+      () =>
+        prompt
+          .pipe(this.model.withStructuredOutput(CategorizationSchema))
+          .invoke(vars),
+      this.fallbackModels.map(
+        (f) => () =>
+          prompt
+            .pipe(f.withStructuredOutput(CategorizationSchema))
+            .invoke(vars),
+      ),
+      STATIC_FALLBACKS.categorization,
+    );
   }
 
   async generateInsights(
@@ -86,11 +104,16 @@ Return a confidence score between 0 and 1.`,
 Transaction summary:
 {summary}`,
     );
+    const vars = { period, summary: buildTransactionSummary(safeTxs) };
+    const parser = new StringOutputParser();
 
-    const chain = prompt
-      .pipe(this.thinkingModel)
-      .pipe(new StringOutputParser());
-    return chain.invoke({ period, summary: buildTransactionSummary(safeTxs) });
+    return invokeWithFallbacks(
+      () => prompt.pipe(this.thinkingModel).pipe(parser).invoke(vars),
+      this.fallbackModels.map(
+        (f) => () => prompt.pipe(f).pipe(parser).invoke(vars),
+      ),
+      STATIC_FALLBACKS.text,
+    );
   }
 
   async generateGoalRecommendation(
@@ -113,15 +136,20 @@ Target: ${safeGoal.targetAmount}
 Recent spending:
 {summary}`,
     );
-
-    const chain = prompt
-      .pipe(this.thinkingModel)
-      .pipe(new StringOutputParser());
-    return chain.invoke({
+    const vars = {
       goalDescription: safeGoal.description,
       deadlineLine,
       summary: buildTransactionSummary(safeTxs),
-    });
+    };
+    const parser = new StringOutputParser();
+
+    return invokeWithFallbacks(
+      () => prompt.pipe(this.thinkingModel).pipe(parser).invoke(vars),
+      this.fallbackModels.map(
+        (f) => () => prompt.pipe(f).pipe(parser).invoke(vars),
+      ),
+      STATIC_FALLBACKS.text,
+    );
   }
 
   async generateWeeklyChallenge(
@@ -141,19 +169,41 @@ Recent spending:
 
 Return exactly one sentence starting with "Spend less than", "Save at least", or "Limit your". Use specific dollar amounts from the data.`,
     );
+    const vars = { from, to, summary: buildTransactionSummary(safeTxs) };
+    const parser = new StringOutputParser();
 
-    const chain = prompt.pipe(this.model).pipe(new StringOutputParser());
-    return chain.invoke({
-      from,
-      to,
-      summary: buildTransactionSummary(safeTxs),
-    });
+    return invokeWithFallbacks(
+      () => prompt.pipe(this.model).pipe(parser).invoke(vars),
+      this.fallbackModels.map(
+        (f) => () => prompt.pipe(f).pipe(parser).invoke(vars),
+      ),
+      STATIC_FALLBACKS.challenge,
+    );
   }
 }
 
 // ---------------------------------------------------------------------------
 // Module-private helpers
 // ---------------------------------------------------------------------------
+
+async function invokeWithFallbacks<T>(
+  primaryFn: () => Promise<T>,
+  fallbackFns: Array<() => Promise<T>>,
+  staticFallback: T,
+): Promise<T> {
+  try {
+    return await primaryFn();
+  } catch {
+    for (const fn of fallbackFns) {
+      try {
+        return await fn();
+      } catch {
+        continue;
+      }
+    }
+    return staticFallback;
+  }
+}
 
 function buildTransactionSummary(transactions: AnonTransaction[]): string {
   if (transactions.length === 0) return 'No transactions available.';

--- a/apps/api/src/ai/anonymizer.ts
+++ b/apps/api/src/ai/anonymizer.ts
@@ -51,6 +51,6 @@ export function scrubDescription(description: string): string {
 // Private helpers
 // ---------------------------------------------------------------------------
 
-function toYearMonth(isoDate: string): string {
-  return isoDate.slice(0, 7); // "YYYY-MM-DD..." → "YYYY-MM"
+function toYearMonth(isoDate: string | Date): string {
+  return new Date(isoDate).toISOString().slice(0, 7); // → "YYYY-MM"
 }

--- a/apps/api/src/ai/llm.factory.spec.ts
+++ b/apps/api/src/ai/llm.factory.spec.ts
@@ -2,6 +2,7 @@ import { ConfigService } from '@nestjs/config';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { ChatOpenAI } from '@langchain/openai';
 import { ChatGroq } from '@langchain/groq';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { createLlmPair } from './llm.factory';
 
 jest.mock('@langchain/anthropic', () => ({
@@ -12,6 +13,9 @@ jest.mock('@langchain/openai', () => ({
 }));
 jest.mock('@langchain/groq', () => ({
   ChatGroq: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock('@langchain/google-genai', () => ({
+  ChatGoogleGenerativeAI: jest.fn().mockImplementation(() => ({})),
 }));
 
 function makeConfig(values: Record<string, string | number>): ConfigService {
@@ -95,6 +99,30 @@ describe('createLlmPair', () => {
         expect.objectContaining({
           apiKey: 'groq-key',
           model: 'llama-3.3-70b-versatile',
+        }),
+      );
+    });
+
+    it('should return the same instance for model and thinkingModel', () => {
+      const { model, thinkingModel } = createLlmPair(config());
+      expect(model).toBe(thinkingModel);
+    });
+  });
+
+  describe('gemini', () => {
+    const config = () =>
+      makeConfig({
+        AI_PROVIDER: 'gemini',
+        AI_MODEL: 'gemini-2.0-flash',
+        GOOGLE_API_KEY: 'google-key',
+      });
+
+    it('should create a ChatGoogleGenerativeAI model', () => {
+      createLlmPair(config());
+      expect(ChatGoogleGenerativeAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'google-key',
+          model: 'gemini-2.0-flash',
         }),
       );
     });

--- a/apps/api/src/ai/llm.factory.spec.ts
+++ b/apps/api/src/ai/llm.factory.spec.ts
@@ -1,0 +1,116 @@
+import { ConfigService } from '@nestjs/config';
+import { ChatAnthropic } from '@langchain/anthropic';
+import { ChatOpenAI } from '@langchain/openai';
+import { ChatGroq } from '@langchain/groq';
+import { createLlmPair } from './llm.factory';
+
+jest.mock('@langchain/anthropic', () => ({
+  ChatAnthropic: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock('@langchain/openai', () => ({
+  ChatOpenAI: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock('@langchain/groq', () => ({
+  ChatGroq: jest.fn().mockImplementation(() => ({})),
+}));
+
+function makeConfig(values: Record<string, string | number>): ConfigService {
+  return {
+    getOrThrow: jest.fn().mockImplementation((key: string) => {
+      if (!(key in values)) throw new Error(`Missing: ${key}`);
+      return values[key];
+    }),
+  } as unknown as ConfigService;
+}
+
+describe('createLlmPair', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('anthropic', () => {
+    const config = () =>
+      makeConfig({
+        AI_PROVIDER: 'anthropic',
+        AI_MODEL: 'claude-opus-4-6',
+        ANTHROPIC_API_KEY: 'ant-key',
+        AI_THINKING_BUDGET_TOKENS: 8000,
+      });
+
+    it('should create a standard ChatAnthropic model', () => {
+      createLlmPair(config());
+      expect(ChatAnthropic).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'ant-key',
+          model: 'claude-opus-4-6',
+        }),
+      );
+    });
+
+    it('should create a thinking ChatAnthropic model with budget from env', () => {
+      createLlmPair(config());
+      expect(ChatAnthropic).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: 'enabled', budget_tokens: 8000 },
+        }),
+      );
+    });
+
+    it('should return distinct model and thinkingModel instances', () => {
+      const { model, thinkingModel } = createLlmPair(config());
+      expect(model).not.toBe(thinkingModel);
+    });
+  });
+
+  describe('openai', () => {
+    const config = () =>
+      makeConfig({
+        AI_PROVIDER: 'openai',
+        AI_MODEL: 'gpt-4o',
+        OPENAI_API_KEY: 'oai-key',
+      });
+
+    it('should create a ChatOpenAI model', () => {
+      createLlmPair(config());
+      expect(ChatOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'oai-key', model: 'gpt-4o' }),
+      );
+    });
+
+    it('should return the same instance for model and thinkingModel', () => {
+      const { model, thinkingModel } = createLlmPair(config());
+      expect(model).toBe(thinkingModel);
+    });
+  });
+
+  describe('groq', () => {
+    const config = () =>
+      makeConfig({
+        AI_PROVIDER: 'groq',
+        AI_MODEL: 'llama-3.3-70b-versatile',
+        GROQ_API_KEY: 'groq-key',
+      });
+
+    it('should create a ChatGroq model', () => {
+      createLlmPair(config());
+      expect(ChatGroq).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'groq-key',
+          model: 'llama-3.3-70b-versatile',
+        }),
+      );
+    });
+
+    it('should return the same instance for model and thinkingModel', () => {
+      const { model, thinkingModel } = createLlmPair(config());
+      expect(model).toBe(thinkingModel);
+    });
+  });
+
+  describe('unknown provider', () => {
+    it('should throw for an unsupported provider', () => {
+      const config = makeConfig({ AI_PROVIDER: 'mistral', AI_MODEL: 'any' });
+      expect(() => createLlmPair(config)).toThrow(
+        /Unsupported AI_PROVIDER.*mistral/,
+      );
+    });
+  });
+});

--- a/apps/api/src/ai/llm.factory.spec.ts
+++ b/apps/api/src/ai/llm.factory.spec.ts
@@ -24,11 +24,17 @@ function makeConfig(values: Record<string, string | number>): ConfigService {
       if (!(key in values)) throw new Error(`Missing: ${key}`);
       return values[key];
     }),
+    // config.get() returns undefined when key is absent (used for optional fallback keys)
+    get: jest.fn().mockImplementation((key: string) => values[key]),
   } as unknown as ConfigService;
 }
 
 describe('createLlmPair', () => {
   beforeEach(() => jest.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // Primary providers
+  // -------------------------------------------------------------------------
 
   describe('anthropic', () => {
     const config = () =>
@@ -139,6 +145,84 @@ describe('createLlmPair', () => {
       expect(() => createLlmPair(config)).toThrow(
         /Unsupported AI_PROVIDER.*mistral/,
       );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Fallback model detection
+  // -------------------------------------------------------------------------
+
+  describe('fallbackModels', () => {
+    it('should include Gemini when GOOGLE_API_KEY is set and provider is not gemini', () => {
+      const config = makeConfig({
+        AI_PROVIDER: 'anthropic',
+        AI_MODEL: 'claude-opus-4-6',
+        ANTHROPIC_API_KEY: 'ant-key',
+        AI_THINKING_BUDGET_TOKENS: 8000,
+        GOOGLE_API_KEY: 'google-key',
+      });
+      const { fallbackModels } = createLlmPair(config);
+      expect(fallbackModels).toHaveLength(1);
+      expect(ChatGoogleGenerativeAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'google-key',
+          model: 'gemini-2.0-flash',
+        }),
+      );
+    });
+
+    it('should include Groq when GROQ_API_KEY is set and provider is not groq', () => {
+      const config = makeConfig({
+        AI_PROVIDER: 'anthropic',
+        AI_MODEL: 'claude-opus-4-6',
+        ANTHROPIC_API_KEY: 'ant-key',
+        AI_THINKING_BUDGET_TOKENS: 8000,
+        GROQ_API_KEY: 'groq-key',
+      });
+      const { fallbackModels } = createLlmPair(config);
+      expect(fallbackModels).toHaveLength(1);
+      expect(ChatGroq).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'groq-key',
+          model: 'llama-3.3-70b-versatile',
+        }),
+      );
+    });
+
+    it('should include Gemini first when both keys are set', () => {
+      const config = makeConfig({
+        AI_PROVIDER: 'anthropic',
+        AI_MODEL: 'claude-opus-4-6',
+        ANTHROPIC_API_KEY: 'ant-key',
+        AI_THINKING_BUDGET_TOKENS: 8000,
+        GOOGLE_API_KEY: 'google-key',
+        GROQ_API_KEY: 'groq-key',
+      });
+      const { fallbackModels } = createLlmPair(config);
+      expect(fallbackModels).toHaveLength(2);
+    });
+
+    it('should not include Gemini as fallback when primary is gemini', () => {
+      const config = makeConfig({
+        AI_PROVIDER: 'gemini',
+        AI_MODEL: 'gemini-2.0-flash',
+        GOOGLE_API_KEY: 'google-key',
+        GROQ_API_KEY: 'groq-key',
+      });
+      const { fallbackModels } = createLlmPair(config);
+      // Only Groq should be a fallback, not Gemini itself
+      expect(fallbackModels).toHaveLength(1);
+    });
+
+    it('should return empty fallbackModels when no fallback keys are set', () => {
+      const config = makeConfig({
+        AI_PROVIDER: 'anthropic',
+        AI_MODEL: 'claude-opus-4-6',
+        ANTHROPIC_API_KEY: 'ant-key',
+        AI_THINKING_BUDGET_TOKENS: 8000,
+      });
+      const { fallbackModels } = createLlmPair(config);
+      expect(fallbackModels).toHaveLength(0);
     });
   });
 });

--- a/apps/api/src/ai/llm.factory.ts
+++ b/apps/api/src/ai/llm.factory.ts
@@ -1,0 +1,58 @@
+import { ConfigService } from '@nestjs/config';
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { ChatAnthropic } from '@langchain/anthropic';
+import { ChatOpenAI } from '@langchain/openai';
+import { ChatGroq } from '@langchain/groq';
+
+export interface LlmPair {
+  /** Standard model — used for categorization and weekly challenges. */
+  model: BaseChatModel;
+  /**
+   * Model with extended thinking when the provider supports it (Anthropic).
+   * Falls back to the standard model for all other providers.
+   */
+  thinkingModel: BaseChatModel;
+}
+
+/**
+ * Creates the appropriate LangChain chat model instances based on AI_PROVIDER.
+ * Supported values: "anthropic" | "openai" | "groq"
+ */
+export function createLlmPair(config: ConfigService): LlmPair {
+  const provider = config.getOrThrow<string>('AI_PROVIDER');
+  const modelName = config.getOrThrow<string>('AI_MODEL');
+
+  switch (provider) {
+    case 'anthropic': {
+      const apiKey = config.getOrThrow<string>('ANTHROPIC_API_KEY');
+      const budgetTokens = config.getOrThrow<number>(
+        'AI_THINKING_BUDGET_TOKENS',
+      );
+      return {
+        model: new ChatAnthropic({ apiKey, model: modelName }),
+        thinkingModel: new ChatAnthropic({
+          apiKey,
+          model: modelName,
+          thinking: { type: 'enabled', budget_tokens: budgetTokens },
+        }),
+      };
+    }
+
+    case 'openai': {
+      const apiKey = config.getOrThrow<string>('OPENAI_API_KEY');
+      const m = new ChatOpenAI({ apiKey, model: modelName });
+      return { model: m, thinkingModel: m };
+    }
+
+    case 'groq': {
+      const apiKey = config.getOrThrow<string>('GROQ_API_KEY');
+      const m = new ChatGroq({ apiKey, model: modelName });
+      return { model: m, thinkingModel: m };
+    }
+
+    default:
+      throw new Error(
+        `Unsupported AI_PROVIDER: "${provider}". Valid values: anthropic, openai, groq`,
+      );
+  }
+}

--- a/apps/api/src/ai/llm.factory.ts
+++ b/apps/api/src/ai/llm.factory.ts
@@ -3,6 +3,7 @@ import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { ChatOpenAI } from '@langchain/openai';
 import { ChatGroq } from '@langchain/groq';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 
 export interface LlmPair {
   /** Standard model — used for categorization and weekly challenges. */
@@ -16,7 +17,7 @@ export interface LlmPair {
 
 /**
  * Creates the appropriate LangChain chat model instances based on AI_PROVIDER.
- * Supported values: "anthropic" | "openai" | "groq"
+ * Supported values: "anthropic" | "openai" | "groq" | "gemini"
  */
 export function createLlmPair(config: ConfigService): LlmPair {
   const provider = config.getOrThrow<string>('AI_PROVIDER');
@@ -50,9 +51,15 @@ export function createLlmPair(config: ConfigService): LlmPair {
       return { model: m, thinkingModel: m };
     }
 
+    case 'gemini': {
+      const apiKey = config.getOrThrow<string>('GOOGLE_API_KEY');
+      const m = new ChatGoogleGenerativeAI({ apiKey, model: modelName });
+      return { model: m, thinkingModel: m };
+    }
+
     default:
       throw new Error(
-        `Unsupported AI_PROVIDER: "${provider}". Valid values: anthropic, openai, groq`,
+        `Unsupported AI_PROVIDER: "${provider}". Valid values: anthropic, openai, groq, gemini`,
       );
   }
 }

--- a/apps/api/src/ai/llm.factory.ts
+++ b/apps/api/src/ai/llm.factory.ts
@@ -99,7 +99,7 @@ function buildFallbackModels(
     const key = config.get<string>('GOOGLE_API_KEY');
     if (key) {
       fallbacks.push(
-        new ChatGoogleGenerativeAI({ apiKey: key, model: 'gemini-2.0-flash' }),
+        new ChatGoogleGenerativeAI({ apiKey: key, model: 'gemini-1.5-flash' }),
       );
     }
   }

--- a/apps/api/src/ai/llm.factory.ts
+++ b/apps/api/src/ai/llm.factory.ts
@@ -13,6 +13,11 @@ export interface LlmPair {
    * Falls back to the standard model for all other providers.
    */
   thinkingModel: BaseChatModel;
+  /**
+   * Ordered list of fallback models built from whichever provider API keys
+   * are present in env. Empty when no fallback keys are configured.
+   */
+  fallbackModels: BaseChatModel[];
 }
 
 /**
@@ -23,6 +28,21 @@ export function createLlmPair(config: ConfigService): LlmPair {
   const provider = config.getOrThrow<string>('AI_PROVIDER');
   const modelName = config.getOrThrow<string>('AI_MODEL');
 
+  const primary = buildPrimary(config, provider, modelName);
+  const fallbackModels = buildFallbackModels(config, provider);
+
+  return { ...primary, fallbackModels };
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+function buildPrimary(
+  config: ConfigService,
+  provider: string,
+  modelName: string,
+): Pick<LlmPair, 'model' | 'thinkingModel'> {
   switch (provider) {
     case 'anthropic': {
       const apiKey = config.getOrThrow<string>('ANTHROPIC_API_KEY');
@@ -62,4 +82,36 @@ export function createLlmPair(config: ConfigService): LlmPair {
         `Unsupported AI_PROVIDER: "${provider}". Valid values: anthropic, openai, groq, gemini`,
       );
   }
+}
+
+/**
+ * Builds an ordered list of fallback models from whichever provider API keys
+ * are available in env — skipping the primary provider.
+ * Order: Gemini → Groq (free tiers first).
+ */
+function buildFallbackModels(
+  config: ConfigService,
+  primaryProvider: string,
+): BaseChatModel[] {
+  const fallbacks: BaseChatModel[] = [];
+
+  if (primaryProvider !== 'gemini') {
+    const key = config.get<string>('GOOGLE_API_KEY');
+    if (key) {
+      fallbacks.push(
+        new ChatGoogleGenerativeAI({ apiKey: key, model: 'gemini-2.0-flash' }),
+      );
+    }
+  }
+
+  if (primaryProvider !== 'groq') {
+    const key = config.get<string>('GROQ_API_KEY');
+    if (key) {
+      fallbacks.push(
+        new ChatGroq({ apiKey: key, model: 'llama-3.3-70b-versatile' }),
+      );
+    }
+  }
+
+  return fallbacks;
 }

--- a/apps/api/src/transactions/dto/create-transaction.dto.ts
+++ b/apps/api/src/transactions/dto/create-transaction.dto.ts
@@ -1,4 +1,11 @@
-import { IsIn, IsISO8601, IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import {
+  IsIn,
+  IsISO8601,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
 import type {
   TransactionCategory,
   TransactionType,
@@ -15,10 +22,17 @@ export class CreateTransactionDto {
   @IsIn(['INCOME', 'EXPENSE'])
   type: TransactionType;
 
-  /** Optional — AI will categorize automatically when omitted */
-  @IsOptional()
-  @IsIn(['Food', 'Transport', 'Bills', 'Entertainment', 'Shopping', 'Health', 'Income', 'Other'])
-  category?: TransactionCategory;
+  @IsIn([
+    'Food',
+    'Transport',
+    'Bills',
+    'Entertainment',
+    'Shopping',
+    'Health',
+    'Income',
+    'Other',
+  ])
+  category: TransactionCategory;
 
   /** ISO-8601 — defaults to now when omitted */
   @IsOptional()

--- a/apps/api/src/transactions/transactions.module.ts
+++ b/apps/api/src/transactions/transactions.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
-import { AiModule } from '../ai/ai.module';
 import { TransactionsController } from './transactions.controller';
 import { TransactionsService } from './transactions.service';
 
 @Module({
-  imports: [AiModule],
   controllers: [TransactionsController],
   providers: [TransactionsService],
   exports: [TransactionsService],

--- a/apps/api/src/transactions/transactions.service.spec.ts
+++ b/apps/api/src/transactions/transactions.service.spec.ts
@@ -1,6 +1,5 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { AiService } from '../ai/ai.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { TransactionsService } from './transactions.service';
 
@@ -15,7 +14,6 @@ const mockTransaction = {
   amount: 5,
   type: 'EXPENSE',
   category: 'Food',
-  aiConfidence: 0.9,
   date: new Date('2025-01-01'),
   createdAt: new Date('2025-01-01'),
 };
@@ -32,10 +30,6 @@ const mockPrisma = {
   $transaction: jest.fn(),
 };
 
-const mockAi = {
-  categorizeTransaction: jest.fn(),
-};
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -50,7 +44,6 @@ describe('TransactionsService', () => {
       providers: [
         TransactionsService,
         { provide: PrismaService, useValue: mockPrisma },
-        { provide: AiService, useValue: mockAi },
       ],
     }).compile();
 
@@ -66,90 +59,30 @@ describe('TransactionsService', () => {
   // -------------------------------------------------------------------------
 
   describe('create', () => {
-    it('should auto-categorize when category is omitted', async () => {
-      mockAi.categorizeTransaction.mockResolvedValue({
-        category: 'Food',
-        confidence: 0.9,
-      });
+    it('should create a transaction with the provided category', async () => {
       mockPrisma.transaction.create.mockResolvedValue(mockTransaction);
 
       const result = await service.create('user-1', {
         description: 'Coffee',
         amount: 5,
         type: 'EXPENSE',
+        category: 'Food',
       });
 
-      expect(mockAi.categorizeTransaction).toHaveBeenCalledWith(
-        'Coffee',
-        5,
-        'EXPENSE',
-      );
       expect(mockPrisma.transaction.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          category: 'Food',
-          aiConfidence: 0.9,
-        }),
+        data: expect.objectContaining({ category: 'Food' }),
       });
       expect(result).toEqual(mockTransaction);
     });
 
-    it('should fall back to Other when AI throws', async () => {
-      mockAi.categorizeTransaction.mockRejectedValue(
-        new Error('AI unavailable'),
-      );
-      mockPrisma.transaction.create.mockResolvedValue({
-        ...mockTransaction,
-        category: 'Other',
-        aiConfidence: null,
-      });
-
-      await service.create('user-1', {
-        description: 'Coffee',
-        amount: 5,
-        type: 'EXPENSE',
-      });
-
-      expect(mockPrisma.transaction.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          category: 'Other',
-          aiConfidence: null,
-        }),
-      });
-    });
-
-    it('should skip AI when category is provided', async () => {
-      mockPrisma.transaction.create.mockResolvedValue({
-        ...mockTransaction,
-        aiConfidence: null,
-      });
-
-      await service.create('user-1', {
-        description: 'Salary',
-        amount: 3000,
-        type: 'INCOME',
-        category: 'Income',
-      });
-
-      expect(mockAi.categorizeTransaction).not.toHaveBeenCalled();
-      expect(mockPrisma.transaction.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          category: 'Income',
-          aiConfidence: null,
-        }),
-      });
-    });
-
     it('should use provided date when given', async () => {
       mockPrisma.transaction.create.mockResolvedValue(mockTransaction);
-      mockAi.categorizeTransaction.mockResolvedValue({
-        category: 'Food',
-        confidence: 0.8,
-      });
 
       await service.create('user-1', {
         description: 'Lunch',
         amount: 12,
         type: 'EXPENSE',
+        category: 'Food',
         date: '2025-06-15T12:00:00.000Z',
       });
 

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { Transaction } from '@prisma/client';
 import type { PaginatedTransactions } from '@financial-advisor/shared';
-import { AiService } from '../ai/ai.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { GetTransactionsQueryDto } from './dto/get-transactions-query.dto';
@@ -12,40 +11,19 @@ const DEFAULT_LIMIT = 20;
 
 @Injectable()
 export class TransactionsService {
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly ai: AiService,
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   async create(
     userId: string,
     dto: CreateTransactionDto,
   ): Promise<Transaction> {
-    let category = dto.category;
-    let aiConfidence: number | null = null;
-
-    if (!category) {
-      try {
-        const result = await this.ai.categorizeTransaction(
-          dto.description,
-          dto.amount,
-          dto.type,
-        );
-        category = result.category;
-        aiConfidence = result.confidence;
-      } catch {
-        category = 'Other';
-      }
-    }
-
     return this.prisma.transaction.create({
       data: {
         userId,
         description: dto.description,
         amount: dto.amount,
         type: dto.type,
-        category,
-        aiConfidence,
+        category: dto.category,
         date: dto.date ? new Date(dto.date) : new Date(),
       },
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "@financial-advisor/shared": "*",
         "@langchain/anthropic": "^1.3.23",
         "@langchain/core": "^1.1.32",
+        "@langchain/groq": "^1.1.5",
+        "@langchain/openai": "^1.2.13",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.3",
         "@nestjs/core": "^11.0.1",
@@ -5594,6 +5596,21 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/@langchain/groq": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@langchain/groq/-/groq-1.1.5.tgz",
+      "integrity": "sha512-mTimterQUjqGYWocEInVFE7iFtood0ZGNl5aI9fXwFLWIXubT4/tZa+iTqwN7y4hZ5hEJ/EtMLGoT15/SiuUpw==",
+      "license": "MIT",
+      "dependencies": {
+        "groq-sdk": "^0.37.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.0"
+      }
+    },
     "node_modules/@langchain/langgraph": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.2.tgz",
@@ -5739,6 +5756,23 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/openai": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.2.13.tgz",
+      "integrity": "sha512-zyspKSBnyxICxZyGYMxsSkCUJR09Uj1omMGBrUsvpSu9j+zIbfNg4+NQTIRmnzULoKB+keaioOdLGHxOQru3+w==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12",
+        "openai": "^6.27.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.32"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -7651,6 +7685,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/passport": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
@@ -8691,6 +8735,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -12132,6 +12188,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -12526,6 +12601,36 @@
       "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
       "license": "MIT"
     },
+    "node_modules/groq-sdk": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-0.37.0.tgz",
+      "integrity": "sha512-lT72pcT8b/X5XrzdKf+rWVzUGW1OQSKESmL8fFN5cTbsf02gq6oFam4SVeNtzELt9cYE2Pt3pdGgSImuTbHFDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/groq-sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/groq-sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -12763,6 +12868,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
@@ -19091,6 +19205,26 @@
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -19344,6 +19478,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.29.0.tgz",
+      "integrity": "sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -23002,6 +23157,15 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@financial-advisor/shared": "*",
         "@langchain/anthropic": "^1.3.23",
         "@langchain/core": "^1.1.32",
+        "@langchain/google-genai": "^2.1.25",
         "@langchain/groq": "^1.1.5",
         "@langchain/openai": "^1.2.13",
         "@nestjs/common": "^11.0.1",
@@ -3212,6 +3213,15 @@
       "resolved": "packages/shared",
       "link": true
     },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
@@ -5584,6 +5594,35 @@
       }
     },
     "node_modules/@langchain/core/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/google-genai": {
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-2.1.25.tgz",
+      "integrity": "sha512-OGqitjcjqXOxbeXmmA6P++bZ/q1QDK5ojzfSQO0YZPWvQJhi+6hw2/tRd4MT57651NKyAiUdACG/r6+SYp3kIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@google/generative-ai": "^0.24.0",
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.32"
+      }
+    },
+    "node_modules/@langchain/google-genai/node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
       "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,9 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.78.0",
         "@financial-advisor/shared": "*",
+        "@langchain/anthropic": "^1.3.23",
+        "@langchain/core": "^1.1.32",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.3",
         "@nestjs/core": "^11.0.1",
@@ -36,6 +37,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "dotenv": "^17.3.1",
+        "langchain": "^1.2.32",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.20.0",
@@ -491,26 +493,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.78.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
-      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2036,6 +2018,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
     },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "10.5.0",
@@ -5511,6 +5499,248 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@langchain/anthropic": {
+      "version": "1.3.23",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.3.23.tgz",
+      "integrity": "sha512-iHCUWKXMZcbjdLZ+mohJMo+tH4HXcZXYktEM02xetpwiqi2vaoDeZsiK/A2kEN24b9QbpG0sLueRNtJHn/fAFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.74.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.32"
+      }
+    },
+    "node_modules/@langchain/anthropic/node_modules/@anthropic-ai/sdk": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.74.0.tgz",
+      "integrity": "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/core": {
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.32.tgz",
+      "integrity": "sha512-ZZNiER5tceFXqZOghfrxNHzM60gcQL5XK/8Ow5+o4OuKHrP1p/RUQBDM9Y1nddi/VmKQj+ncaXXM5KovXTEGGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.2.tgz",
+      "integrity": "sha512-1F94azb3b3TpHi5Jxa7gFvAYXuSIsEobEXk3/PD7+gkOobIC5Jty3+/ATSkH7joUo0bXCF/rgMOjRGusi6YvSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.0.0",
+        "@langchain/langgraph-sdk": "~1.7.0",
+        "@standard-schema/spec": "1.1.0",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
+        "zod": "^3.25.32 || ^4.2.0",
+        "zod-to-json-schema": "^3.x"
+      },
+      "peerDependenciesMeta": {
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.0.tgz",
+      "integrity": "sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.1"
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.7.2.tgz",
+      "integrity": "sha512-8ad5OTwqc15J/DxLNJYLn3IC2mpfow09nxJdszxhwm3KgsolGZIUV6g7m67C2p4j3cbQZD5USHt3hKEL0ahqoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1",
+        "uuid": "^13.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^18.0.0 || ^19.0.0 || ^20.0.0",
+        "@langchain/core": "^1.1.16",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/core": {
+          "optional": true
+        },
+        "@langchain/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/p-queue": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
+      "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -7387,7 +7617,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -7545,6 +7774,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@types/validator": {
@@ -9952,6 +10187,15 @@
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "license": "ISC"
     },
+    "node_modules/console-table-printer": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
+      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
+      "license": "MIT",
+      "dependencies": {
+        "simple-wcswidth": "^1.1.2"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -10190,6 +10434,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -10935,7 +11188,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -12782,6 +13034,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -16656,6 +16920,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -16944,6 +17217,101 @@
       "license": "MIT",
       "bin": {
         "lan-network": "dist/lan-network-cli.js"
+      }
+    },
+    "node_modules/langchain": {
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.2.32.tgz",
+      "integrity": "sha512-LwT0+ClCx9dLDSt8SQpZAdOHLlmcbPJUvUhFgS18boGfKvUFbXom8+xN20wiHMktwB3RB1CRyDLPRMP+tMabMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph": "^1.1.2",
+        "@langchain/langgraph-checkpoint": "^1.0.0",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.32"
+      }
+    },
+    "node_modules/langchain/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.10.tgz",
+      "integrity": "sha512-unBdaaD/CqAOLIYjd9kT33FgHUMvHSsyBIPbQa+p/rE/Sv/l4pAC5ISEE79zphxi+vV4qxHqEgqahVXj2Xvz7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "chalk": "^5.6.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/leven": {
@@ -18585,6 +18953,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -19096,6 +19473,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -19125,6 +19511,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -20913,6 +21348,12 @@
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
+    },
+    "node_modules/simple-wcswidth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",


### PR DESCRIPTION
## Summary

Closes #52

Replaces the direct Anthropic SDK internals in `AiService` with LangChain LCEL chains, making the AI layer provider-agnostic and production-ready.

- **Multi-provider support** — `AI_PROVIDER` env var switches between `anthropic`, `openai`, `groq`, `gemini`
- **Modular factory** — `llm.factory.ts` builds the primary model and thinking model per provider
- **Fallback chain** — primary → Gemini (if `GOOGLE_API_KEY` set) → Groq (if `GROQ_API_KEY` set) → static response
- **Error logging** — each fallback failure logged at WARN, total failure logged at ERROR
- **PII anonymization** — all transaction/goal data scrubbed before reaching the LLM
- **LangSmith tracing** — enabled via `LANGCHAIN_TRACING_V2=true`
- **Remove AI auto-categorization** — `categorizeTransaction` removed; category is now required from the user form (agent tool planned for later)
- **Bug fix** — `toYearMonth` now handles Prisma `Date` objects (not just ISO strings)

## Test plan

- [x] All 115 unit tests pass
- [x] Build passes (pre-push hook verified)
- [x] Smoke tested `GET /insights?period=weekly` — Gemini 2.5 Flash returns real AI-generated insights
- [x] Verified fallback logging in server output when quota exceeded