### PR TITLE
feat(prisma): add ChatSession + ChatMessage models

### DIFF
--- a/apps/api/prisma/migrations/20260316042802_add_chat_models/migration.sql
+++ b/apps/api/prisma/migrations/20260316042802_add_chat_models/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "ChatSession" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChatSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ChatMessage" (
+    "id" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "toolName" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ChatMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ChatSession_userId_idx" ON "ChatSession"("userId");
+
+-- CreateIndex
+CREATE INDEX "ChatSession_userId_createdAt_idx" ON "ChatSession"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ChatMessage_sessionId_idx" ON "ChatMessage"("sessionId");
+
+-- CreateIndex
+CREATE INDEX "ChatMessage_sessionId_createdAt_idx" ON "ChatMessage"("sessionId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ChatSession" ADD CONSTRAINT "ChatSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChatMessage" ADD CONSTRAINT "ChatMessage_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "ChatSession"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -65,6 +65,7 @@ model User {
   transactions Transaction[]
   goals        Goal[]
   challenges   Challenge[]
+  chatSessions ChatSession[]
 
   @@index([email])
 }
@@ -118,4 +119,32 @@ model Challenge {
 
   @@index([userId])
   @@index([userId, weekStart])
+}
+
+model ChatSession {
+  id        String        @id @default(uuid())
+  userId    String
+  title     String?
+  messages  ChatMessage[]
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([userId, createdAt])
+}
+
+model ChatMessage {
+  id        String   @id @default(uuid())
+  sessionId String
+  role      String   // "user" | "assistant" | "tool"
+  content   String   @db.Text
+  toolName  String?
+  createdAt DateTime @default(now())
+
+  session ChatSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+
+  @@index([sessionId])
+  @@index([sessionId, createdAt])
 }

--- a/packages/shared/src/types/chat.types.ts
+++ b/packages/shared/src/types/chat.types.ts
@@ -1,0 +1,25 @@
+export interface ChatSessionSummary {
+  id: string;
+  title: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChatMessageDto {
+  id: string;
+  role: 'user' | 'assistant' | 'tool';
+  content: string;
+  toolName?: string | null;
+  createdAt: string;
+}
+
+export interface ChatSessionDetail extends ChatSessionSummary {
+  messages: ChatMessageDto[];
+}
+
+export type ChatStreamEvent =
+  | { type: 'token'; data: { content: string } }
+  | { type: 'tool_call'; data: { tool: string; args: Record<string, unknown> } }
+  | { type: 'tool_result'; data: { tool: string; result: unknown } }
+  | { type: 'done'; data: { messageId: string } }
+  | { type: 'error'; data: { message: string } };

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -8,3 +8,4 @@ export * from './transaction.types';
 export * from './goal.types';
 export * from './insight.types';
 export * from './challenge.types';
+export * from './chat.types';


### PR DESCRIPTION
## Summary
- Adds `ChatSession` and `ChatMessage` Prisma models with cascading deletes and composite indexes
- Adds `chatSessions` relation to `User` model
- Runs migration `add_chat_models` against Neon DB
- Adds shared types: `ChatSessionSummary`, `ChatMessageDto`, `ChatSessionDetail`, `ChatStreamEvent` to `packages/shared`

## Test plan
- [x] `npx prisma migrate dev` applied cleanly
- [x] `npm run build --workspace=packages/shared` compiles with no errors

Closes #55