### PR TITLE
feat(chat): add ChatModule with LangGraph agent and SSE endpoint

### DIFF
--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -30,6 +30,10 @@ export class AiService {
     this.fallbackModels = fallbackModels;
   }
 
+  getModel(): BaseChatModel {
+    return this.model;
+  }
+
   async generateInsights(
     transactions: Transaction[],
     period: InsightPeriod,

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -8,6 +8,7 @@ import { TransactionsModule } from './transactions/transactions.module';
 import { GoalsModule } from './goals/goals.module';
 import { InsightsModule } from './insights/insights.module';
 import { ChallengesModule } from './challenges/challenges.module';
+import { ChatModule } from './chat/chat.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { ChallengesModule } from './challenges/challenges.module';
     GoalsModule,
     InsightsModule,
     ChallengesModule,
+    ChatModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/chat/chat-agent.service.ts
+++ b/apps/api/src/chat/chat-agent.service.ts
@@ -55,7 +55,10 @@ export class ChatAgentService {
       if (chunk.event === 'on_tool_end') {
         yield {
           type: 'tool_result',
-          data: { tool: chunk.name ?? '', result: chunk.data?.output },
+          data: {
+            tool: chunk.name ?? '',
+            result: extractToolOutput(chunk.data?.output),
+          },
         };
       }
     }
@@ -72,6 +75,22 @@ function buildSystemPrompt(userName: string): string {
 You have access to ${userName}'s real financial data via tools — always use tools to answer questions, never guess numbers.
 Be concise, specific, and cite actual amounts from the data.
 Never reveal raw IDs or internal fields. If data is unavailable, say so honestly.`;
+}
+
+function extractToolOutput(output: unknown): unknown {
+  if (output === null || output === undefined) return null;
+  // LangChain ToolMessage — extract the string content
+  if (typeof output === 'object' && 'content' in (output as object)) {
+    const content = (output as { content: unknown }).content;
+    if (typeof content === 'string') {
+      try {
+        return JSON.parse(content);
+      } catch {
+        return content;
+      }
+    }
+  }
+  return output;
 }
 
 function extractToken(content: unknown): string | null {

--- a/apps/api/src/chat/chat-agent.service.ts
+++ b/apps/api/src/chat/chat-agent.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { createReactAgent } from '@langchain/langgraph/prebuilt';
+import { SystemMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { AiService } from '../ai/ai.service';
+import { ChatToolsService, buildTools } from './chat-tools.service';
+import type { ChatStreamEvent } from '@financial-advisor/shared';
+
+const HISTORY_WINDOW = 20;
+
+@Injectable()
+export class ChatAgentService {
+  constructor(
+    private readonly ai: AiService,
+    private readonly toolsService: ChatToolsService,
+  ) {}
+
+  async *stream(
+    userId: string,
+    userName: string,
+    messages: BaseMessage[],
+  ): AsyncGenerator<ChatStreamEvent> {
+    const tools = buildTools(this.toolsService, userId);
+    const model = this.ai.getModel();
+
+    const agent = createReactAgent({
+      llm: model,
+      tools,
+      stateModifier: new SystemMessage(buildSystemPrompt(userName)),
+    });
+
+    const windowed = messages.slice(-HISTORY_WINDOW);
+
+    for await (const chunk of agent.streamEvents(
+      { messages: windowed },
+      { version: 'v2' },
+    )) {
+      if (chunk.event === 'on_chat_model_stream') {
+        const raw = chunk.data?.chunk?.content;
+        // content can be a string or an array of content blocks (Anthropic thinking)
+        const token = extractToken(raw);
+        if (token) yield { type: 'token', data: { content: token } };
+      }
+
+      if (chunk.event === 'on_tool_start') {
+        yield {
+          type: 'tool_call',
+          data: {
+            tool: chunk.name ?? '',
+            args: (chunk.data?.input ?? {}) as Record<string, unknown>,
+          },
+        };
+      }
+
+      if (chunk.event === 'on_tool_end') {
+        yield {
+          type: 'tool_result',
+          data: { tool: chunk.name ?? '', result: chunk.data?.output },
+        };
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-private helpers
+// ---------------------------------------------------------------------------
+
+function buildSystemPrompt(userName: string): string {
+  const today = new Date().toISOString().split('T')[0];
+  return `You are Fina, a personal finance assistant. Today is ${today}.
+You have access to ${userName}'s real financial data via tools — always use tools to answer questions, never guess numbers.
+Be concise, specific, and cite actual amounts from the data.
+Never reveal raw IDs or internal fields. If data is unavailable, say so honestly.`;
+}
+
+function extractToken(content: unknown): string | null {
+  if (typeof content === 'string') return content || null;
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (typeof block === 'object' && block !== null && 'type' in block) {
+        const b = block as { type: string; text?: string };
+        if (b.type === 'text' && b.text) return b.text;
+      }
+    }
+  }
+  return null;
+}

--- a/apps/api/src/chat/chat-tools.service.ts
+++ b/apps/api/src/chat/chat-tools.service.ts
@@ -1,0 +1,199 @@
+import { Injectable } from '@nestjs/common';
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { PrismaService } from '../prisma/prisma.service';
+
+export interface AnonTransaction {
+  amount: number;
+  type: string;
+  category: string;
+  date: string;
+  description: string;
+}
+
+export interface AnonGoal {
+  description: string;
+  targetAmount: number;
+  deadline: string | null;
+  aiRecommendation: string | null;
+}
+
+export interface CategorySummary {
+  category: string;
+  total: number;
+  count: number;
+}
+
+@Injectable()
+export class ChatToolsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getTransactions(
+    userId: string,
+    args: { from?: string; to?: string; category?: string; limit?: number },
+  ): Promise<AnonTransaction[]> {
+    const rows = await this.prisma.transaction.findMany({
+      where: {
+        userId,
+        ...(args.category ? { category: args.category as any } : {}),
+        ...(args.from || args.to
+          ? {
+              date: {
+                ...(args.from ? { gte: new Date(args.from) } : {}),
+                ...(args.to ? { lte: new Date(args.to) } : {}),
+              },
+            }
+          : {}),
+      },
+      orderBy: { date: 'desc' },
+      take: args.limit ?? 50,
+    });
+
+    return rows.map((t) => ({
+      amount: t.amount,
+      type: t.type,
+      category: t.category,
+      date: t.date.toISOString().split('T')[0]!,
+      description: t.description,
+    }));
+  }
+
+  async getGoals(userId: string): Promise<AnonGoal[]> {
+    const rows = await this.prisma.goal.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return rows.map((g) => ({
+      description: g.description,
+      targetAmount: g.targetAmount,
+      deadline: g.deadline ? g.deadline.toISOString().split('T')[0]! : null,
+      aiRecommendation: g.aiRecommendation,
+    }));
+  }
+
+  async getSpendingSummary(
+    userId: string,
+    args: { period: 'weekly' | 'monthly' },
+  ): Promise<CategorySummary[]> {
+    const now = new Date();
+    const from =
+      args.period === 'weekly'
+        ? new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+        : new Date(now.getFullYear(), now.getMonth(), 1);
+
+    const rows = await this.prisma.transaction.findMany({
+      where: { userId, date: { gte: from }, type: 'EXPENSE' },
+    });
+
+    const byCategory = rows.reduce<
+      Record<string, { total: number; count: number }>
+    >((acc, t) => {
+      acc[t.category] ??= { total: 0, count: 0 };
+      acc[t.category]!.total += t.amount;
+      acc[t.category]!.count += 1;
+      return acc;
+    }, {});
+
+    return Object.entries(byCategory).map(([category, { total, count }]) => ({
+      category,
+      total: Math.round(total * 100) / 100,
+      count,
+    }));
+  }
+
+  async getActiveChallenge(
+    userId: string,
+  ): Promise<{
+    description: string;
+    weekStart: string;
+    weekEnd: string;
+  } | null> {
+    const challenge = await this.prisma.challenge.findFirst({
+      where: { userId, status: 'ACTIVE' },
+      orderBy: { weekStart: 'desc' },
+    });
+
+    if (!challenge) return null;
+
+    return {
+      description: challenge.description,
+      weekStart: challenge.weekStart.toISOString().split('T')[0]!,
+      weekEnd: challenge.weekEnd.toISOString().split('T')[0]!,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Build tool definitions with userId bound in closure
+// ---------------------------------------------------------------------------
+
+export function buildTools(
+  service: ChatToolsService,
+  userId: string,
+): DynamicStructuredTool[] {
+  return [
+    new DynamicStructuredTool({
+      name: 'get_transactions',
+      description:
+        "Fetch the user's transactions. Filter by date range, category, or limit. Returns amount, type, category, date, description.",
+      schema: z.object({
+        from: z
+          .string()
+          .optional()
+          .describe('ISO date string, e.g. 2025-01-01'),
+        to: z.string().optional().describe('ISO date string, e.g. 2025-01-31'),
+        category: z
+          .enum([
+            'Food',
+            'Transport',
+            'Bills',
+            'Entertainment',
+            'Shopping',
+            'Health',
+            'Income',
+            'Other',
+          ])
+          .optional()
+          .describe('Filter by category'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe('Max records to return'),
+      }),
+      func: (args) =>
+        service.getTransactions(userId, args).then((r) => JSON.stringify(r)),
+    }),
+
+    new DynamicStructuredTool({
+      name: 'get_goals',
+      description: 'Fetch all savings goals for the user.',
+      schema: z.object({}),
+      func: () => service.getGoals(userId).then((r) => JSON.stringify(r)),
+    }),
+
+    new DynamicStructuredTool({
+      name: 'get_spending_summary',
+      description:
+        'Get total spending by category for the current week or month.',
+      schema: z.object({
+        period: z
+          .enum(['weekly', 'monthly'])
+          .describe('weekly = last 7 days, monthly = current calendar month'),
+      }),
+      func: (args) =>
+        service.getSpendingSummary(userId, args).then((r) => JSON.stringify(r)),
+    }),
+
+    new DynamicStructuredTool({
+      name: 'get_active_challenge',
+      description: "Get the user's most recent active weekly challenge.",
+      schema: z.object({}),
+      func: () =>
+        service.getActiveChallenge(userId).then((r) => JSON.stringify(r)),
+    }),
+  ];
+}

--- a/apps/api/src/chat/chat-tools.service.ts
+++ b/apps/api/src/chat/chat-tools.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { PrismaService } from '../prisma/prisma.service';
@@ -26,12 +26,16 @@ export interface CategorySummary {
 
 @Injectable()
 export class ChatToolsService {
+  private readonly logger = new Logger(ChatToolsService.name);
+
   constructor(private readonly prisma: PrismaService) {}
 
   async getTransactions(
     userId: string,
     args: { from?: string; to?: string; category?: string; limit?: number },
   ): Promise<AnonTransaction[]> {
+    this.logger.log(`getTransactions called — args: ${JSON.stringify(args)}`);
+
     const rows = await this.prisma.transaction.findMany({
       where: {
         userId,
@@ -39,8 +43,8 @@ export class ChatToolsService {
         ...(args.from || args.to
           ? {
               date: {
-                ...(args.from ? { gte: new Date(args.from) } : {}),
-                ...(args.to ? { lte: new Date(args.to) } : {}),
+                ...(args.from ? { gte: startOfDay(args.from) } : {}),
+                ...(args.to ? { lte: endOfDay(args.to) } : {}),
               },
             }
           : {}),
@@ -49,20 +53,30 @@ export class ChatToolsService {
       take: args.limit ?? 50,
     });
 
+    this.logger.log(`getTransactions result — ${rows.length} rows`);
+
     return rows.map((t) => ({
       amount: t.amount,
       type: t.type,
       category: t.category,
-      date: t.date.toISOString().split('T')[0]!,
+      // Shift back 12 h so transactions entered late evening in western
+      // timezones (stored as next-day UTC) display with the correct local date.
+      date: new Date(t.date.getTime() - 12 * 60 * 60 * 1000)
+        .toISOString()
+        .split('T')[0]!,
       description: t.description,
     }));
   }
 
   async getGoals(userId: string): Promise<AnonGoal[]> {
+    this.logger.log(`getGoals called — userId: ${userId}`);
+
     const rows = await this.prisma.goal.findMany({
       where: { userId },
       orderBy: { createdAt: 'desc' },
     });
+
+    this.logger.log(`getGoals result — ${rows.length} rows`);
 
     return rows.map((g) => ({
       description: g.description,
@@ -76,6 +90,8 @@ export class ChatToolsService {
     userId: string,
     args: { period: 'weekly' | 'monthly' },
   ): Promise<CategorySummary[]> {
+    this.logger.log(`getSpendingSummary called — period: ${args.period}`);
+
     const now = new Date();
     const from =
       args.period === 'weekly'
@@ -102,13 +118,13 @@ export class ChatToolsService {
     }));
   }
 
-  async getActiveChallenge(
-    userId: string,
-  ): Promise<{
+  async getActiveChallenge(userId: string): Promise<{
     description: string;
     weekStart: string;
     weekEnd: string;
   } | null> {
+    this.logger.log(`getActiveChallenge called — userId: ${userId}`);
+
     const challenge = await this.prisma.challenge.findFirst({
       where: { userId, status: 'ACTIVE' },
       orderBy: { weekStart: 'desc' },
@@ -164,8 +180,17 @@ export function buildTools(
           .optional()
           .describe('Max records to return'),
       }),
-      func: (args) =>
-        service.getTransactions(userId, args).then((r) => JSON.stringify(r)),
+      func: (raw) => {
+        const args = parseArgs<{
+          from?: string;
+          to?: string;
+          category?: string;
+          limit?: number;
+        }>(raw);
+        return service
+          .getTransactions(userId, args)
+          .then((r) => JSON.stringify(r));
+      },
     }),
 
     new DynamicStructuredTool({
@@ -184,8 +209,12 @@ export function buildTools(
           .enum(['weekly', 'monthly'])
           .describe('weekly = last 7 days, monthly = current calendar month'),
       }),
-      func: (args) =>
-        service.getSpendingSummary(userId, args).then((r) => JSON.stringify(r)),
+      func: (raw) => {
+        const args = parseArgs<{ period: 'weekly' | 'monthly' }>(raw);
+        return service
+          .getSpendingSummary(userId, args)
+          .then((r) => JSON.stringify(r));
+      },
     }),
 
     new DynamicStructuredTool({
@@ -196,4 +225,43 @@ export function buildTools(
         service.getActiveChallenge(userId).then((r) => JSON.stringify(r)),
     }),
   ];
+}
+
+// ---------------------------------------------------------------------------
+// Module-private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Some models (e.g. Gemini) call tools with a legacy single-string format:
+ *   { input: '{"from":"...","category":"Food"}' }
+ * instead of a structured object. This helper unwraps that string so the
+ * actual filter args are always available regardless of model.
+ */
+function parseArgs<T extends object>(raw: unknown): T {
+  if (raw && typeof raw === 'object' && 'input' in raw) {
+    const inputVal = (raw as { input: unknown }).input;
+    if (typeof inputVal === 'string') {
+      try {
+        return JSON.parse(inputVal) as T;
+      } catch {
+        // fall through — return raw
+      }
+    }
+  }
+  return raw as T;
+}
+
+function startOfDay(dateStr: string): Date {
+  const d = new Date(dateStr);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+function endOfDay(dateStr: string): Date {
+  // Extend 12 h past UTC midnight to cover UTC-12 (westernmost) timezone:
+  // a transaction recorded at e.g. 8 pm EST (UTC-5) on date X is stored as
+  // X+1T01:00Z — without this buffer those rows would be missed.
+  const d = new Date(dateStr);
+  d.setUTCHours(35, 59, 59, 999); // 23 + 12 = 35 → rolls to next day 11:59:59 Z
+  return d;
 }

--- a/apps/api/src/chat/chat.controller.spec.ts
+++ b/apps/api/src/chat/chat.controller.spec.ts
@@ -1,0 +1,157 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ChatController } from './chat.controller';
+import { ChatService } from './chat.service';
+
+const NOW_ISO = '2025-01-15T12:00:00.000Z';
+
+const mockSession = {
+  id: 'sess-1',
+  title: null,
+  createdAt: NOW_ISO,
+  updatedAt: NOW_ISO,
+};
+
+const mockService = {
+  createSession: jest.fn(),
+  getSessions: jest.fn(),
+  getSession: jest.fn(),
+  deleteSession: jest.fn(),
+  streamMessage: jest.fn(),
+};
+
+const authReq = { user: { id: 'user-1' } };
+
+describe('ChatController', () => {
+  let controller: ChatController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChatController],
+      providers: [{ provide: ChatService, useValue: mockService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<ChatController>(ChatController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('createSession', () => {
+    it('should delegate to service and return session', async () => {
+      mockService.createSession.mockResolvedValue(mockSession);
+
+      const result = await controller.createSession(authReq as any, {
+        title: 'Test',
+      });
+
+      expect(mockService.createSession).toHaveBeenCalledWith('user-1', 'Test');
+      expect(result).toEqual(mockSession);
+    });
+  });
+
+  describe('getSessions', () => {
+    it('should return list of sessions', async () => {
+      mockService.getSessions.mockResolvedValue([mockSession]);
+
+      const result = await controller.getSessions(authReq as any);
+
+      expect(mockService.getSessions).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual([mockSession]);
+    });
+  });
+
+  describe('getSession', () => {
+    it('should return session detail', async () => {
+      const detail = { ...mockSession, messages: [] };
+      mockService.getSession.mockResolvedValue(detail);
+
+      const result = await controller.getSession(authReq as any, 'sess-1');
+
+      expect(mockService.getSession).toHaveBeenCalledWith('user-1', 'sess-1');
+      expect(result).toEqual(detail);
+    });
+
+    it('should propagate NotFoundException', async () => {
+      mockService.getSession.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.getSession(authReq as any, 'bad'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteSession', () => {
+    it('should call service delete', async () => {
+      mockService.deleteSession.mockResolvedValue(undefined);
+
+      await controller.deleteSession(authReq as any, 'sess-1');
+
+      expect(mockService.deleteSession).toHaveBeenCalledWith(
+        'user-1',
+        'sess-1',
+      );
+    });
+  });
+
+  describe('sendMessage (SSE)', () => {
+    function makeRes() {
+      return { write: jest.fn(), end: jest.fn() };
+    }
+
+    async function* fakeStream(events: object[]) {
+      for (const e of events) yield e;
+    }
+
+    it('should write SSE events and end response', async () => {
+      mockService.streamMessage.mockReturnValue(
+        fakeStream([
+          { type: 'token', data: { content: 'Hi' } },
+          { type: 'done', data: { messageId: 'msg-1' } },
+        ]),
+      );
+
+      const res = makeRes();
+      await controller.sendMessage(
+        authReq as any,
+        'sess-1',
+        { content: 'Hello' },
+        res as any,
+      );
+
+      expect(res.write).toHaveBeenCalledWith(
+        `event: token\ndata: ${JSON.stringify({ content: 'Hi' })}\n\n`,
+      );
+      expect(res.write).toHaveBeenCalledWith(
+        `event: done\ndata: ${JSON.stringify({ messageId: 'msg-1' })}\n\n`,
+      );
+      expect(res.end).toHaveBeenCalled();
+    });
+
+    it('should write error event and end when stream throws', async () => {
+      mockService.streamMessage.mockImplementation(async function* () {
+        throw new Error('agent failed');
+      });
+
+      const res = makeRes();
+      await controller.sendMessage(
+        authReq as any,
+        'sess-1',
+        { content: 'Hello' },
+        res as any,
+      );
+
+      expect(res.write).toHaveBeenCalledWith(
+        `event: error\ndata: ${JSON.stringify({ message: 'agent failed' })}\n\n`,
+      );
+      expect(res.end).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Header,
+  HttpCode,
+  Param,
+  Post,
+  Request,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CreateSessionDto } from './dto/create-session.dto';
+import { SendMessageDto } from './dto/send-message.dto';
+import { ChatService } from './chat.service';
+
+interface AuthRequest {
+  user: { id: string };
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller('api/chat')
+export class ChatController {
+  constructor(private readonly chat: ChatService) {}
+
+  @Post('sessions')
+  createSession(@Request() req: AuthRequest, @Body() dto: CreateSessionDto) {
+    return this.chat.createSession(req.user.id, dto.title);
+  }
+
+  @Get('sessions')
+  getSessions(@Request() req: AuthRequest) {
+    return this.chat.getSessions(req.user.id);
+  }
+
+  @Get('sessions/:id')
+  getSession(@Request() req: AuthRequest, @Param('id') id: string) {
+    return this.chat.getSession(req.user.id, id);
+  }
+
+  @Delete('sessions/:id')
+  @HttpCode(204)
+  deleteSession(@Request() req: AuthRequest, @Param('id') id: string) {
+    return this.chat.deleteSession(req.user.id, id);
+  }
+
+  @Post('sessions/:id/messages')
+  @Header('Content-Type', 'text/event-stream')
+  @Header('Cache-Control', 'no-cache')
+  @Header('Connection', 'keep-alive')
+  async sendMessage(
+    @Request() req: AuthRequest,
+    @Param('id') id: string,
+    @Body() dto: SendMessageDto,
+    @Res() res: Response,
+  ): Promise<void> {
+    try {
+      for await (const event of this.chat.streamMessage(
+        req.user.id,
+        id,
+        dto.content,
+      )) {
+        res.write(
+          `event: ${event.type}\ndata: ${JSON.stringify(event.data)}\n\n`,
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      res.write(`event: error\ndata: ${JSON.stringify({ message })}\n\n`);
+    } finally {
+      res.end();
+    }
+  }
+}

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -22,7 +22,7 @@ interface AuthRequest {
 }
 
 @UseGuards(JwtAuthGuard)
-@Controller('api/chat')
+@Controller('chat')
 export class ChatController {
   constructor(private readonly chat: ChatService) {}
 

--- a/apps/api/src/chat/chat.module.ts
+++ b/apps/api/src/chat/chat.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { AiModule } from '../ai/ai.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { ChatController } from './chat.controller';
+import { ChatService } from './chat.service';
+import { ChatAgentService } from './chat-agent.service';
+import { ChatToolsService } from './chat-tools.service';
+
+@Module({
+  imports: [PrismaModule, AiModule],
+  controllers: [ChatController],
+  providers: [ChatService, ChatAgentService, ChatToolsService],
+})
+export class ChatModule {}

--- a/apps/api/src/chat/chat.service.spec.ts
+++ b/apps/api/src/chat/chat.service.spec.ts
@@ -1,0 +1,256 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../prisma/prisma.service';
+import { ChatAgentService } from './chat-agent.service';
+import { ChatService } from './chat.service';
+
+const NOW = new Date('2025-01-15T12:00:00Z');
+
+const mockSession = {
+  id: 'sess-1',
+  userId: 'user-1',
+  title: null,
+  createdAt: NOW,
+  updatedAt: NOW,
+  messages: [],
+};
+
+const mockUser = {
+  id: 'user-1',
+  name: 'Alice',
+  email: 'alice@example.com',
+};
+
+const mockPrisma = {
+  chatSession: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  chatMessage: {
+    create: jest.fn(),
+  },
+  user: {
+    findUniqueOrThrow: jest.fn(),
+  },
+};
+
+async function* emptyStream() {}
+
+const mockAgent = {
+  stream: jest.fn().mockReturnValue(emptyStream()),
+};
+
+describe('ChatService', () => {
+  let service: ChatService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChatService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: ChatAgentService, useValue: mockAgent },
+      ],
+    }).compile();
+
+    service = module.get<ChatService>(ChatService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createSession', () => {
+    it('should create and return a session summary', async () => {
+      mockPrisma.chatSession.create.mockResolvedValue(mockSession);
+
+      const result = await service.createSession('user-1');
+
+      expect(mockPrisma.chatSession.create).toHaveBeenCalledWith({
+        data: { userId: 'user-1', title: null },
+      });
+      expect(result.id).toBe('sess-1');
+      expect(result.title).toBeNull();
+    });
+
+    it('should pass title when provided', async () => {
+      mockPrisma.chatSession.create.mockResolvedValue({
+        ...mockSession,
+        title: 'My chat',
+      });
+
+      const result = await service.createSession('user-1', 'My chat');
+
+      expect(mockPrisma.chatSession.create).toHaveBeenCalledWith({
+        data: { userId: 'user-1', title: 'My chat' },
+      });
+      expect(result.title).toBe('My chat');
+    });
+  });
+
+  describe('getSessions', () => {
+    it('should return all sessions ordered by createdAt desc', async () => {
+      mockPrisma.chatSession.findMany.mockResolvedValue([mockSession]);
+
+      const result = await service.getSessions('user-1');
+
+      expect(mockPrisma.chatSession.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('getSession', () => {
+    it('should return session detail with messages', async () => {
+      const sessionWithMessages = {
+        ...mockSession,
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'user',
+            content: 'Hello',
+            toolName: null,
+            createdAt: NOW,
+          },
+        ],
+      };
+      mockPrisma.chatSession.findFirst.mockResolvedValue(sessionWithMessages);
+
+      const result = await service.getSession('user-1', 'sess-1');
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0]?.role).toBe('user');
+    });
+
+    it('should throw NotFoundException when session not found', async () => {
+      mockPrisma.chatSession.findFirst.mockResolvedValue(null);
+
+      await expect(service.getSession('user-1', 'bad-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('deleteSession', () => {
+    it('should delete the session', async () => {
+      mockPrisma.chatSession.findFirst.mockResolvedValue(mockSession);
+      mockPrisma.chatSession.delete.mockResolvedValue(mockSession);
+
+      await service.deleteSession('user-1', 'sess-1');
+
+      expect(mockPrisma.chatSession.delete).toHaveBeenCalledWith({
+        where: { id: 'sess-1' },
+      });
+    });
+
+    it('should throw NotFoundException when session not owned', async () => {
+      mockPrisma.chatSession.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.deleteSession('user-1', 'other-sess'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('streamMessage', () => {
+    it('should throw NotFoundException when session not owned', async () => {
+      mockPrisma.chatSession.findFirst.mockResolvedValue(null);
+
+      const gen = service.streamMessage('user-1', 'bad-sess', 'hello');
+      await expect(gen.next()).rejects.toThrow(NotFoundException);
+    });
+
+    it('should auto-set title on first message', async () => {
+      mockPrisma.chatSession.findFirst.mockResolvedValue({
+        ...mockSession,
+        messages: [],
+      });
+      mockPrisma.chatSession.update.mockResolvedValue({});
+      mockPrisma.chatMessage.create.mockResolvedValue({ id: 'msg-1' });
+      mockPrisma.user.findUniqueOrThrow.mockResolvedValue(mockUser);
+      mockAgent.stream.mockReturnValue(emptyStream());
+
+      const events = [];
+      for await (const e of service.streamMessage(
+        'user-1',
+        'sess-1',
+        'What is my balance?',
+      )) {
+        events.push(e);
+      }
+
+      expect(mockPrisma.chatSession.update).toHaveBeenCalledWith({
+        where: { id: 'sess-1' },
+        data: { title: 'What is my balance?' },
+      });
+    });
+
+    it('should not overwrite title when session already has one', async () => {
+      mockPrisma.chatSession.findFirst.mockResolvedValue({
+        ...mockSession,
+        title: 'Existing title',
+        messages: [],
+      });
+      mockPrisma.chatMessage.create.mockResolvedValue({ id: 'msg-1' });
+      mockPrisma.user.findUniqueOrThrow.mockResolvedValue(mockUser);
+      mockAgent.stream.mockReturnValue(emptyStream());
+
+      const events = [];
+      for await (const e of service.streamMessage(
+        'user-1',
+        'sess-1',
+        'Hello',
+      )) {
+        events.push(e);
+      }
+
+      expect(mockPrisma.chatSession.update).not.toHaveBeenCalled();
+    });
+
+    it('should persist user and assistant messages and yield done event', async () => {
+      mockPrisma.chatSession.findFirst.mockResolvedValue({
+        ...mockSession,
+        title: 'My chat',
+        messages: [],
+      });
+      mockPrisma.chatMessage.create
+        .mockResolvedValueOnce({ id: 'user-msg-1' })
+        .mockResolvedValueOnce({ id: 'asst-msg-1' });
+      mockPrisma.user.findUniqueOrThrow.mockResolvedValue(mockUser);
+
+      async function* fakeStream() {
+        yield { type: 'token' as const, data: { content: 'Hello' } };
+        yield { type: 'token' as const, data: { content: ' there!' } };
+      }
+      mockAgent.stream.mockReturnValue(fakeStream());
+
+      const events = [];
+      for await (const e of service.streamMessage('user-1', 'sess-1', 'Hi')) {
+        events.push(e);
+      }
+
+      // user message persisted
+      expect(mockPrisma.chatMessage.create).toHaveBeenNthCalledWith(1, {
+        data: { sessionId: 'sess-1', role: 'user', content: 'Hi' },
+      });
+      // assistant message persisted with accumulated text
+      expect(mockPrisma.chatMessage.create).toHaveBeenNthCalledWith(2, {
+        data: {
+          sessionId: 'sess-1',
+          role: 'assistant',
+          content: 'Hello there!',
+        },
+      });
+      // done event is last
+      const last = events[events.length - 1];
+      expect(last?.type).toBe('done');
+      expect((last as any).data.messageId).toBe('asst-msg-1');
+    });
+  });
+});

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -1,0 +1,166 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { HumanMessage, AIMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { PrismaService } from '../prisma/prisma.service';
+import { ChatAgentService } from './chat-agent.service';
+import type {
+  ChatSessionSummary,
+  ChatSessionDetail,
+  ChatMessageDto,
+  ChatStreamEvent,
+} from '@financial-advisor/shared';
+
+@Injectable()
+export class ChatService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly agent: ChatAgentService,
+  ) {}
+
+  async createSession(
+    userId: string,
+    title?: string,
+  ): Promise<ChatSessionSummary> {
+    const session = await this.prisma.chatSession.create({
+      data: { userId, title: title ?? null },
+    });
+    return toSessionSummary(session);
+  }
+
+  async getSessions(userId: string): Promise<ChatSessionSummary[]> {
+    const sessions = await this.prisma.chatSession.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+    return sessions.map(toSessionSummary);
+  }
+
+  async getSession(
+    userId: string,
+    sessionId: string,
+  ): Promise<ChatSessionDetail> {
+    const session = await this.prisma.chatSession.findFirst({
+      where: { id: sessionId, userId },
+      include: { messages: { orderBy: { createdAt: 'asc' } } },
+    });
+    if (!session) throw new NotFoundException('Chat session not found');
+
+    return {
+      ...toSessionSummary(session),
+      messages: session.messages.map(toMessageDto),
+    };
+  }
+
+  async deleteSession(userId: string, sessionId: string): Promise<void> {
+    const session = await this.prisma.chatSession.findFirst({
+      where: { id: sessionId, userId },
+    });
+    if (!session) throw new NotFoundException('Chat session not found');
+    await this.prisma.chatSession.delete({ where: { id: sessionId } });
+  }
+
+  async *streamMessage(
+    userId: string,
+    sessionId: string,
+    content: string,
+  ): AsyncGenerator<ChatStreamEvent> {
+    // 1. Verify session ownership
+    const session = await this.prisma.chatSession.findFirst({
+      where: { id: sessionId, userId },
+      include: { messages: { orderBy: { createdAt: 'asc' } } },
+    });
+    if (!session) throw new NotFoundException('Chat session not found');
+
+    // 2. Auto-set title on first user message
+    if (!session.title && session.messages.length === 0) {
+      await this.prisma.chatSession.update({
+        where: { id: sessionId },
+        data: { title: content.slice(0, 60) },
+      });
+    }
+
+    // 3. Persist user message
+    await this.prisma.chatMessage.create({
+      data: { sessionId, role: 'user', content },
+    });
+
+    // 4. Load user info for system prompt
+    const user = await this.prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+    });
+    const userName = user.name ?? 'User';
+
+    // 5. Convert DB messages → LangChain messages (include new user message)
+    const allMessages: BaseMessage[] = [
+      ...session.messages.map(toBaseMessage),
+      new HumanMessage(content),
+    ];
+
+    // 6. Stream agent events, accumulate assistant text
+    let assistantText = '';
+    for await (const event of this.agent.stream(
+      userId,
+      userName,
+      allMessages,
+    )) {
+      if (event.type === 'token') assistantText += event.data.content;
+      yield event;
+    }
+
+    // 7. Persist assistant message
+    const saved = await this.prisma.chatMessage.create({
+      data: { sessionId, role: 'assistant', content: assistantText },
+    });
+
+    // 8. Signal completion
+    yield { type: 'done', data: { messageId: saved.id } };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-private helpers
+// ---------------------------------------------------------------------------
+
+function toSessionSummary(session: {
+  id: string;
+  title: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): ChatSessionSummary {
+  return {
+    id: session.id,
+    title: session.title,
+    createdAt: session.createdAt.toISOString(),
+    updatedAt: session.updatedAt.toISOString(),
+  };
+}
+
+function toMessageDto(msg: {
+  id: string;
+  role: string;
+  content: string;
+  toolName: string | null;
+  createdAt: Date;
+}): ChatMessageDto {
+  return {
+    id: msg.id,
+    role: msg.role as ChatMessageDto['role'],
+    content: msg.content,
+    toolName: msg.toolName,
+    createdAt: msg.createdAt.toISOString(),
+  };
+}
+
+function toBaseMessage(msg: {
+  role: string;
+  content: string;
+  toolName: string | null;
+}): BaseMessage {
+  if (msg.role === 'user') return new HumanMessage(msg.content);
+  if (msg.role === 'tool')
+    return new ToolMessage({
+      content: msg.content,
+      tool_call_id: msg.toolName ?? '',
+    });
+  return new AIMessage(msg.content);
+}

--- a/apps/api/src/chat/dto/create-session.dto.ts
+++ b/apps/api/src/chat/dto/create-session.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateSessionDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  title?: string;
+}

--- a/apps/api/src/chat/dto/send-message.dto.ts
+++ b/apps/api/src/chat/dto/send-message.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class SendMessageDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  content!: string;
+}


### PR DESCRIPTION
## Summary
- `ChatToolsService`: 4 LangGraph tools (`get_transactions`, `get_goals`, `get_spending_summary`, `get_active_challenge`) using `DynamicStructuredTool` + zod schemas, all scoped to `userId`
- `ChatAgentService`: `createReactAgent` with Fina system prompt + today's date, 20-message sliding window, streams `token`/`tool_call`/`tool_result` events
- `ChatService`: session CRUD + `streamMessage()` generator — persists user + assistant messages, auto-sets session title on first message
- `ChatController`: REST CRUD + SSE `POST /api/chat/sessions/:id/messages` with proper `text/event-stream` headers
- `AiService`: added `getModel()` method
- Registered `ChatModule` in `AppModule`

## Test plan
- [x] 20 new tests pass (`chat.service.spec.ts`, `chat.controller.spec.ts`)
- [x] `npm run build -w apps/api` clean
- [x] Pre-existing `llm.factory.spec.ts` failure is unrelated (model name mismatch in old test)

Closes #56