### PR TITLE
fix(api): enable SSE streaming on Vercel via @vercel/node + flushHeaders

### DIFF
--- a/apps/api/src/chat/chat.controller.spec.ts
+++ b/apps/api/src/chat/chat.controller.spec.ts
@@ -103,7 +103,7 @@ describe('ChatController', () => {
 
   describe('sendMessage (SSE)', () => {
     function makeRes() {
-      return { write: jest.fn(), end: jest.fn() };
+      return { write: jest.fn(), end: jest.fn(), flushHeaders: jest.fn() };
     }
 
     async function* fakeStream(events: object[]) {

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -51,12 +51,17 @@ export class ChatController {
   @Header('Content-Type', 'text/event-stream')
   @Header('Cache-Control', 'no-cache')
   @Header('Connection', 'keep-alive')
+  @Header('X-Accel-Buffering', 'no')
   async sendMessage(
     @Request() req: AuthRequest,
     @Param('id') id: string,
     @Body() dto: SendMessageDto,
     @Res() res: Response,
   ): Promise<void> {
+    // Flush headers immediately so the client sees the SSE stream open
+    // before the first token arrives (critical for Vercel's proxy layer).
+    res.flushHeaders();
+
     try {
       for await (const event of this.chat.streamMessage(
         req.user.id,

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "dist/lambda.js",
+      "use": "@vercel/node",
+      "config": {
+        "includeFiles": ["dist/**/*", "node_modules/.prisma/**/*"]
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/dist/lambda.js"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `apps/api/vercel.json` — explicitly configures `@vercel/node` builder with `dist/lambda.js` as the function entry and `includeFiles` for Prisma binaries
- Adds `X-Accel-Buffering: no` response header to disable nginx/proxy buffering
- Calls `res.flushHeaders()` before the event loop so Vercel's proxy sees the SSE stream open before the first token arrives
- Updates controller test to include `flushHeaders` in the mock `res` object

## Why this fixes streaming
Vercel's standard Node.js serverless runtime buffers `res.write()` unless the function's response is flushed eagerly. `res.flushHeaders()` commits the `text/event-stream` headers immediately, signalling to `@vercel/node` and the Vercel proxy layer that this is a long-lived streaming response rather than a single-shot JSON response. Combined with `X-Accel-Buffering: no`, each subsequent `res.write()` chunk is forwarded to the client as it arrives.

## Test plan
- [ ] Deploy to Vercel dev environment
- [ ] Send a chat message — tokens should appear word-by-word without waiting for full response
- [ ] Tool call events stream correctly (green pill appears then clears)
- [ ] `done` event with `messageId` arrives at end
- [ ] All other API endpoints unaffected

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)