### PR TITLE
feat(mobile): polish Goals screen

### DIFF
--- a/apps/mobile/src/components/ui/GoalCard.tsx
+++ b/apps/mobile/src/components/ui/GoalCard.tsx
@@ -1,45 +1,78 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import type { Goal } from '@financial-advisor/shared';
-import { ProgressBar } from './ProgressBar';
 import { colors, radius, spacing, typography } from '../../theme';
 
-const PROGRESS_COLORS = [colors.primary, colors.success, colors.warning];
+const ACCENT_COLORS = [colors.primary, colors.success, colors.warning, colors.danger];
 
 interface Props {
   goal: Goal;
   index: number;
-  savedAmount?: number; // optional — not in the API model yet
 }
 
 function formatDeadline(deadline: string | null) {
   if (!deadline) return null;
   try {
-    return new Date(deadline).toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+    return new Date(deadline).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
   } catch {
     return null;
   }
 }
 
-export function GoalCard({ goal, index, savedAmount = 0 }: Props) {
-  const progress = goal.targetAmount > 0 ? savedAmount / goal.targetAmount : 0;
-  const pct = Math.round(Math.min(1, progress) * 100);
-  const barColor = PROGRESS_COLORS[index % PROGRESS_COLORS.length];
+function daysUntil(deadline: string | null): number | null {
+  if (!deadline) return null;
+  try {
+    return Math.ceil((new Date(deadline).getTime() - Date.now()) / 86_400_000);
+  } catch {
+    return null;
+  }
+}
+
+export function GoalCard({ goal, index }: Props) {
+  const accent = ACCENT_COLORS[index % ACCENT_COLORS.length];
   const deadline = formatDeadline(goal.deadline);
+  const days = daysUntil(goal.deadline);
 
   return (
     <View style={styles.card}>
-      <View style={styles.header}>
-        <View style={styles.headerLeft}>
-          <Text style={styles.name} numberOfLines={1}>{goal.description}</Text>
-          {deadline && <Text style={styles.deadline}>Target: {deadline}</Text>}
+      <View style={[styles.accentBar, { backgroundColor: accent }]} />
+
+      <View style={styles.body}>
+        <View style={styles.topRow}>
+          <Text style={styles.description} numberOfLines={2}>
+            {goal.description}
+          </Text>
+          <View style={[styles.targetBadge, { backgroundColor: accent + '1a' }]}>
+            <Text style={[styles.targetAmount, { color: accent }]}>
+              ${goal.targetAmount.toLocaleString()}
+            </Text>
+          </View>
         </View>
-        <Text style={[styles.pct, { color: barColor }]}>{pct}%</Text>
-      </View>
-      <ProgressBar progress={progress} color={barColor} />
-      <View style={styles.amounts}>
-        <Text style={styles.saved}>${savedAmount.toLocaleString()} saved</Text>
-        <Text style={styles.target}>of ${goal.targetAmount.toLocaleString()}</Text>
+
+        {deadline && (
+          <View style={styles.metaRow}>
+            <Ionicons name="calendar-outline" size={12} color={colors.textMuted} />
+            <Text style={styles.metaText}>Target: {deadline}</Text>
+            {days !== null && days > 0 && <Text style={styles.daysChip}>{days}d left</Text>}
+            {days !== null && days <= 0 && (
+              <Text style={[styles.daysChip, styles.daysOverdue]}>Overdue</Text>
+            )}
+          </View>
+        )}
+
+        {goal.aiRecommendation && (
+          <View style={styles.aiRow}>
+            <Ionicons name="sparkles" size={11} color={colors.primary} />
+            <Text style={styles.aiText} numberOfLines={3}>
+              {goal.aiRecommendation}
+            </Text>
+          </View>
+        )}
       </View>
     </View>
   );
@@ -48,48 +81,79 @@ export function GoalCard({ goal, index, savedAmount = 0 }: Props) {
 const styles = StyleSheet.create({
   card: {
     backgroundColor: colors.surface,
-    borderWidth:     1,
-    borderColor:     colors.border,
-    borderRadius:    radius.lg - 2,
-    padding:         spacing['3'] + 1,
-    marginBottom:    spacing['2'] + 2,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    marginBottom: spacing['3'],
+    flexDirection: 'row',
+    overflow: 'hidden',
   },
-  header: {
-    flexDirection:   'row',
-    justifyContent:  'space-between',
-    alignItems:      'flex-start',
-    marginBottom:    spacing['2'] + 1,
+  accentBar: {
+    width: 4,
   },
-  headerLeft: {
+  body: {
     flex: 1,
-    marginRight: spacing['2'],
+    padding: spacing['3'],
+    gap: 8,
   },
-  name: {
-    fontSize:   13,
-    fontWeight: typography.weight.bold,
-    color:      colors.textPrimary,
-  },
-  deadline: {
-    fontSize:  10,
-    color:     colors.textMuted,
-    marginTop: 1,
-  },
-  pct: {
-    fontSize:   15,
-    fontWeight: typography.weight.bold,
-  },
-  amounts: {
-    flexDirection:  'row',
+  topRow: {
+    flexDirection: 'row',
     justifyContent: 'space-between',
-    marginTop:      7,
+    alignItems: 'flex-start',
+    gap: spacing['2'],
   },
-  saved: {
-    fontSize:   11,
+  description: {
+    flex: 1,
+    fontSize: typography.size.base,
     fontWeight: typography.weight.semibold,
-    color:      colors.textPrimary,
+    color: colors.textPrimary,
+    lineHeight: 20,
   },
-  target: {
-    fontSize: 11,
-    color:    colors.textMuted,
+  targetBadge: {
+    borderRadius: radius.md,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    flexShrink: 0,
+  },
+  targetAmount: {
+    fontSize: typography.size.base,
+    fontWeight: typography.weight.bold,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  metaText: {
+    flex: 1,
+    fontSize: typography.size.sm,
+    color: colors.textMuted,
+  },
+  daysChip: {
+    fontSize: typography.size.xs,
+    fontWeight: typography.weight.medium,
+    color: colors.warning,
+    backgroundColor: colors.warningSubtle,
+    paddingVertical: 2,
+    paddingHorizontal: 6,
+    borderRadius: radius.full,
+  },
+  daysOverdue: {
+    color: colors.danger,
+    backgroundColor: colors.dangerSubtle,
+  },
+  aiRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 5,
+    backgroundColor: colors.primarySubtle,
+    borderRadius: radius.md,
+    padding: spacing['2'],
+  },
+  aiText: {
+    flex: 1,
+    fontSize: typography.size.xs,
+    color: colors.primary,
+    lineHeight: 16,
   },
 });

--- a/apps/mobile/src/screens/Goals/GoalsScreen.tsx
+++ b/apps/mobile/src/screens/Goals/GoalsScreen.tsx
@@ -1,33 +1,52 @@
 import React, { useEffect, useState } from 'react';
 import {
-  View, Text, ScrollView, StyleSheet, TouchableOpacity,
-  TextInput, Modal, SafeAreaView, ActivityIndicator, KeyboardAvoidingView, Platform,
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  TextInput,
+  Modal,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
-import { Ionicons }       from '@expo/vector-icons';
-import { useGoalsStore }  from '../../store/goalsStore';
-import { GoalCard }       from '../../components/ui/GoalCard';
-import { InsightCard }    from '../../components/ui/InsightCard';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { Ionicons } from '@expo/vector-icons';
+import { useGoalsStore } from '../../store/goalsStore';
+import { GoalCard } from '../../components/ui/GoalCard';
 import { colors, spacing, typography, radius } from '../../theme';
 import { strings } from '../../content/strings';
 
 export default function GoalsScreen() {
+  const tabBarHeight = useBottomTabBarHeight();
   const { goals, loading, fetchGoals, createGoal } = useGoalsStore();
   const [modalVisible, setModalVisible] = useState(false);
-  const [description, setDescription]   = useState('');
-  const [targetAmount, setTargetAmount]  = useState('');
-  const [deadline, setDeadline]          = useState('');
-  const [saving, setSaving]              = useState(false);
-  const [error, setError]                = useState('');
+  const [description, setDescription] = useState('');
+  const [targetAmount, setTargetAmount] = useState('');
+  const [deadline, setDeadline] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     fetchGoals();
   }, []);
 
-  const aiRecommendation = goals.find((g) => g.aiRecommendation)?.aiRecommendation;
+  function closeModal() {
+    setModalVisible(false);
+    setDescription('');
+    setTargetAmount('');
+    setDeadline('');
+    setError('');
+  }
 
   async function handleCreate() {
     setError('');
-    if (!description.trim()) { setError(strings.errors.requiredField); return; }
+    if (!description.trim()) {
+      setError(strings.errors.requiredField);
+      return;
+    }
     const amount = parseFloat(targetAmount);
     if (!targetAmount || isNaN(amount) || amount <= 0) {
       setError(strings.errors.invalidAmount);
@@ -40,10 +59,7 @@ export default function GoalsScreen() {
         targetAmount: amount,
         deadline: deadline || undefined,
       });
-      setModalVisible(false);
-      setDescription('');
-      setTargetAmount('');
-      setDeadline('');
+      closeModal();
     } catch {
       setError(strings.common.error);
     } finally {
@@ -52,7 +68,7 @@ export default function GoalsScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.safe}>
+    <SafeAreaView edges={['top']} style={[styles.safe, { paddingBottom: tabBarHeight }]}>
       {/* Header */}
       <View style={styles.header}>
         <Text style={styles.title}>{strings.goals.title}</Text>
@@ -61,7 +77,8 @@ export default function GoalsScreen() {
           onPress={() => setModalVisible(true)}
           activeOpacity={0.8}
         >
-          <Text style={styles.newBtnText}>+ {strings.goals.addButton}</Text>
+          <Ionicons name="add" size={18} color={colors.textInverse} />
+          <Text style={styles.newBtnText}>{strings.goals.addButton}</Text>
         </TouchableOpacity>
       </View>
 
@@ -79,43 +96,34 @@ export default function GoalsScreen() {
         ))}
 
         {!loading && goals.length === 0 && (
-          <Text style={styles.empty}>{strings.goals.empty}</Text>
-        )}
-
-        {aiRecommendation && (
-          <InsightCard text={aiRecommendation} />
+          <View style={styles.emptyWrap}>
+            <Ionicons name="flag-outline" size={36} color={colors.textMuted} />
+            <Text style={styles.emptyTitle}>No goals yet</Text>
+            <Text style={styles.emptyBody}>
+              Set a savings target and Fina will give you an AI-powered plan to reach it.
+            </Text>
+          </View>
         )}
 
         <View style={styles.bottomPad} />
       </ScrollView>
 
       {/* Create goal modal */}
-      <Modal
-        visible={modalVisible}
-        transparent
-        animationType="slide"
-        onRequestClose={() => setModalVisible(false)}
-      >
+      <Modal visible={modalVisible} transparent animationType="slide" onRequestClose={closeModal}>
         <KeyboardAvoidingView
           style={styles.modalOverlay}
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         >
-          <TouchableOpacity
-            style={styles.modalBackdrop}
-            onPress={() => setModalVisible(false)}
-            activeOpacity={1}
-          />
+          <TouchableOpacity style={styles.modalBackdrop} onPress={closeModal} activeOpacity={1} />
           <View style={styles.modalSheet}>
             <View style={styles.handle} />
             <View style={styles.modalHeader}>
-              <Text style={styles.modalTitle}>{strings.goals.addButton}</Text>
-              <TouchableOpacity
-                style={styles.closeBtn}
-                onPress={() => setModalVisible(false)}
-              >
-                <Ionicons name="close" size={14} color={colors.textSecondary} />
+              <Text style={styles.modalTitle}>New goal</Text>
+              <TouchableOpacity style={styles.closeBtn} onPress={closeModal}>
+                <Ionicons name="close" size={16} color={colors.textSecondary} />
               </TouchableOpacity>
             </View>
+
             <ScrollView
               contentContainerStyle={styles.modalBody}
               keyboardShouldPersistTaps="handled"
@@ -142,10 +150,12 @@ export default function GoalsScreen() {
                 />
               </View>
 
-              <Text style={styles.fieldLabel}>{strings.goals.deadlineLabel}</Text>
+              <Text style={styles.fieldLabel}>
+                {strings.goals.deadlineLabel} <Text style={styles.optionalLabel}>(optional)</Text>
+              </Text>
               <TextInput
                 style={styles.input}
-                placeholder="YYYY-MM-DD (optional)"
+                placeholder="YYYY-MM-DD"
                 placeholderTextColor={colors.textMuted}
                 value={deadline}
                 onChangeText={setDeadline}
@@ -159,10 +169,11 @@ export default function GoalsScreen() {
                 disabled={saving}
                 activeOpacity={0.85}
               >
-                {saving
-                  ? <ActivityIndicator color={colors.textInverse} />
-                  : <Text style={styles.saveBtnText}>{strings.goals.submitButton}</Text>
-                }
+                {saving ? (
+                  <ActivityIndicator color={colors.textInverse} />
+                ) : (
+                  <Text style={styles.saveBtnText}>{strings.goals.submitButton}</Text>
+                )}
               </TouchableOpacity>
             </ScrollView>
           </View>
@@ -174,159 +185,180 @@ export default function GoalsScreen() {
 
 const styles = StyleSheet.create({
   safe: {
-    flex:            1,
+    flex: 1,
     backgroundColor: colors.background,
   },
   header: {
-    flexDirection:    'row',
-    justifyContent:   'space-between',
-    alignItems:       'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     paddingHorizontal: spacing['4'],
-    paddingVertical:  spacing['3'],
-    backgroundColor:  colors.surface,
+    paddingTop: spacing['3'],
+    paddingBottom: 14,
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
     borderBottomColor: colors.border,
   },
   title: {
-    fontSize:   21,
+    fontSize: 26,
     fontWeight: typography.weight.bold,
-    color:      colors.textPrimary,
+    color: colors.textPrimary,
+    letterSpacing: -0.3,
   },
   newBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
     backgroundColor: colors.primary,
-    borderRadius:    9,
-    paddingVertical: 6,
-    paddingHorizontal: 11,
+    borderRadius: radius.md,
+    paddingVertical: 7,
+    paddingHorizontal: 12,
   },
   newBtnText: {
-    fontSize:   11,
+    fontSize: typography.size.sm,
     fontWeight: typography.weight.semibold,
-    color:      colors.textInverse,
+    color: colors.textInverse,
   },
   scroll: {
     flex: 1,
   },
   content: {
-    padding: spacing['3'] + 1,
+    padding: spacing['4'],
   },
   loader: {
     marginTop: spacing['8'],
   },
-  empty: {
-    fontSize:        typography.size.base,
-    color:           colors.textMuted,
-    textAlign:       'center',
-    paddingVertical: spacing['8'],
+  emptyWrap: {
+    alignItems: 'center',
+    paddingVertical: spacing['10'],
+    gap: spacing['2'],
+  },
+  emptyTitle: {
+    fontSize: typography.size.md,
+    fontWeight: typography.weight.semibold,
+    color: colors.textSecondary,
+    marginTop: spacing['2'],
+  },
+  emptyBody: {
+    fontSize: typography.size.sm,
+    color: colors.textMuted,
+    textAlign: 'center',
+    maxWidth: 260,
+    lineHeight: 20,
   },
   bottomPad: {
-    height: 100,
+    height: 24,
   },
   modalOverlay: {
-    flex:           1,
+    flex: 1,
     justifyContent: 'flex-end',
-    backgroundColor: 'rgba(0,0,0,0.32)',
+    backgroundColor: colors.overlay,
   },
   modalBackdrop: {
     flex: 1,
   },
   modalSheet: {
     backgroundColor: colors.surface,
-    borderTopLeftRadius:  radius.xl,
+    borderTopLeftRadius: radius.xl,
     borderTopRightRadius: radius.xl,
     maxHeight: '80%',
   },
   handle: {
-    width:           34,
-    height:          4,
+    width: 34,
+    height: 4,
     backgroundColor: colors.border,
-    borderRadius:    radius.full,
-    alignSelf:       'center',
-    marginTop:       spacing['2'] + 2,
+    borderRadius: radius.full,
+    alignSelf: 'center',
+    marginTop: spacing['2'],
   },
   modalHeader: {
-    flexDirection:    'row',
-    justifyContent:   'space-between',
-    alignItems:       'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     paddingHorizontal: spacing['4'],
-    paddingVertical:  spacing['3'],
+    paddingVertical: spacing['3'],
     borderBottomWidth: 1,
     borderBottomColor: colors.border,
   },
   modalTitle: {
-    fontSize:   15,
+    fontSize: typography.size.md,
     fontWeight: typography.weight.bold,
-    color:      colors.textPrimary,
+    color: colors.textPrimary,
   },
   closeBtn: {
-    width:           26,
-    height:          26,
-    borderRadius:    13,
+    width: 28,
+    height: 28,
+    borderRadius: 14,
     backgroundColor: colors.surfaceAlt,
-    alignItems:      'center',
-    justifyContent:  'center',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   modalBody: {
     padding: spacing['4'],
+    paddingBottom: spacing['6'],
   },
   fieldLabel: {
-    fontSize:     11,
-    fontWeight:   typography.weight.medium,
-    color:        colors.textPrimary,
-    marginBottom: 4,
-    marginTop:    spacing['3'],
+    fontSize: typography.size.sm,
+    fontWeight: typography.weight.medium,
+    color: colors.textPrimary,
+    marginBottom: 6,
+    marginTop: spacing['3'],
+  },
+  optionalLabel: {
+    fontWeight: typography.weight.regular,
+    color: colors.textMuted,
   },
   input: {
-    backgroundColor:   colors.background,
-    borderWidth:       1.5,
-    borderColor:       colors.border,
-    borderRadius:      radius.md - 2,
+    backgroundColor: colors.background,
+    borderWidth: 1.5,
+    borderColor: colors.border,
+    borderRadius: radius.md,
     paddingHorizontal: spacing['3'],
-    paddingVertical:   spacing['2'] + 2,
-    fontSize:          13,
-    color:             colors.textPrimary,
+    paddingVertical: spacing['3'],
+    fontSize: typography.size.base,
+    color: colors.textPrimary,
   },
   amountRow: {
-    flexDirection:     'row',
-    alignItems:        'center',
-    backgroundColor:   colors.background,
-    borderWidth:       1.5,
-    borderColor:       colors.primary,
-    borderRadius:      radius.md - 2,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.background,
+    borderWidth: 1.5,
+    borderColor: colors.primary,
+    borderRadius: radius.md,
     paddingHorizontal: spacing['3'],
-    paddingVertical:   spacing['2'] + 2,
-    gap:               4,
+    paddingVertical: spacing['2'],
+    gap: 4,
   },
   currencySign: {
-    fontSize:   17,
+    fontSize: typography.size.lg,
     fontWeight: typography.weight.semibold,
-    color:      colors.primary,
+    color: colors.primary,
   },
   amountInput: {
-    flex:       1,
-    fontSize:   22,
+    flex: 1,
+    fontSize: typography.size.xl,
     fontWeight: typography.weight.bold,
-    color:      colors.textPrimary,
-    padding:    0,
+    color: colors.textPrimary,
+    padding: 0,
   },
   errorText: {
-    fontSize:     typography.size.sm,
-    color:        colors.danger,
-    marginTop:    spacing['2'],
-    marginBottom: spacing['2'],
+    fontSize: typography.size.sm,
+    color: colors.danger,
+    marginTop: spacing['2'],
   },
   saveBtn: {
     backgroundColor: colors.primary,
-    borderRadius:    radius.md,
-    paddingVertical: spacing['3'] + 1,
-    alignItems:      'center',
-    marginTop:       spacing['4'],
+    borderRadius: radius.md,
+    paddingVertical: spacing['3'],
+    alignItems: 'center',
+    marginTop: spacing['4'],
   },
   saveBtnDisabled: {
     opacity: 0.6,
   },
   saveBtnText: {
-    color:      colors.textInverse,
-    fontSize:   typography.size.base,
+    color: colors.textInverse,
+    fontSize: typography.size.base,
     fontWeight: typography.weight.semibold,
   },
 });


### PR DESCRIPTION
## Summary
- Header title 21px → 26px (matches Transactions/Chat)
- Switch to `SafeAreaView` from `react-native-safe-area-context` + `useBottomTabBarHeight()`
- **Removed misleading 0% progress bar** — `Goal` has no `currentAmount` field, so progress was always 0. Replaced with a clear target-focused card
- `GoalCard` redesigned: left accent bar per goal, prominent target amount badge, deadline + days-left chip, AI recommendation row using `colors.primarySubtle`
- Empty state: icon + title + explanatory body instead of bare text
- Modal: title bumped to `typography.size.md`, field labels to `typography.size.sm`, input font to `typography.size.base`, overlay uses `colors.overlay`

Closes #16
🤖 Generated with [Claude Code](https://claude.com/claude-code)