### PR TITLE
feat(mobile): polish Challenge screen

### DIFF
--- a/apps/mobile/src/components/ui/ChallengeCard.tsx
+++ b/apps/mobile/src/components/ui/ChallengeCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import type { Challenge } from '@financial-advisor/shared';
 import { ProgressBar } from './ProgressBar';
 import { colors, radius, spacing, typography } from '../../theme';
@@ -7,9 +8,8 @@ import { colors, radius, spacing, typography } from '../../theme';
 function formatWeek(weekStart: string, weekEnd: string) {
   try {
     const start = new Date(weekStart);
-    const end   = new Date(weekEnd);
-    const fmt   = (d: Date) =>
-      d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    const end = new Date(weekEnd);
+    const fmt = (d: Date) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
     return `${fmt(start)} – ${fmt(end)}`;
   } catch {
     return '';
@@ -17,12 +17,11 @@ function formatWeek(weekStart: string, weekEnd: string) {
 }
 
 function weekProgress(weekStart: string, weekEnd: string) {
-  const now   = Date.now();
+  const now = Date.now();
   const start = new Date(weekStart).getTime();
-  const end   = new Date(weekEnd).getTime();
-  const days  = Math.round((end - start) / 86_400_000) || 7;
-  const elapsed = Math.max(0, now - start);
-  const daysIn  = Math.min(days, Math.floor(elapsed / 86_400_000));
+  const end = new Date(weekEnd).getTime();
+  const days = Math.round((end - start) / 86_400_000) || 7;
+  const daysIn = Math.min(days, Math.floor(Math.max(0, now - start) / 86_400_000));
   return { daysIn, days };
 }
 
@@ -37,23 +36,30 @@ export function ChallengeCard({ challenge, onComplete, onGiveUp, loading }: Prop
   const week = formatWeek(challenge.weekStart, challenge.weekEnd);
   const { daysIn, days } = weekProgress(challenge.weekStart, challenge.weekEnd);
   const progress = days > 0 ? daysIn / days : 0;
+  const daysLeft = Math.max(0, days - daysIn);
 
   return (
     <View style={styles.card}>
+      {/* Week badge */}
       <View style={styles.weekBadge}>
-        <Text style={styles.weekBadgeText}>{week} · This week</Text>
+        <Ionicons name="calendar-outline" size={11} color={colors.primary} />
+        <Text style={styles.weekBadgeText}>{week}</Text>
       </View>
 
+      {/* Challenge description */}
       <Text style={styles.desc}>{challenge.description}</Text>
 
-      <View style={styles.statusRow}>
-        <View style={[styles.dot, styles.dotActive]} />
-        <Text style={styles.statusText}>In progress</Text>
-        <Text style={styles.daysText}>{daysIn} of {days} days</Text>
+      {/* Progress row */}
+      <View style={styles.progressHeader}>
+        <View style={styles.statusRow}>
+          <View style={styles.dot} />
+          <Text style={styles.statusText}>In progress</Text>
+        </View>
+        <Text style={styles.daysText}>{daysLeft > 0 ? `${daysLeft} days left` : 'Last day!'}</Text>
       </View>
+      <ProgressBar progress={progress} color={colors.warning} height={6} />
 
-      <ProgressBar progress={progress} color={colors.warning} height={5} />
-
+      {/* Actions */}
       <View style={styles.buttons}>
         <TouchableOpacity
           style={styles.btnComplete}
@@ -61,10 +67,14 @@ export function ChallengeCard({ challenge, onComplete, onGiveUp, loading }: Prop
           disabled={loading}
           activeOpacity={0.8}
         >
-          {loading
-            ? <ActivityIndicator color={colors.textInverse} size="small" />
-            : <Text style={styles.btnCompleteText}>Mark as complete</Text>
-          }
+          {loading ? (
+            <ActivityIndicator color={colors.textInverse} size="small" />
+          ) : (
+            <>
+              <Ionicons name="checkmark-circle-outline" size={16} color={colors.textInverse} />
+              <Text style={styles.btnCompleteText}>Mark complete</Text>
+            </>
+          )}
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.btnGiveUp}
@@ -82,83 +92,92 @@ export function ChallengeCard({ challenge, onComplete, onGiveUp, loading }: Prop
 const styles = StyleSheet.create({
   card: {
     backgroundColor: colors.surface,
-    borderWidth:     1,
-    borderColor:     colors.border,
-    borderRadius:    radius.lg,
-    padding:         spacing['4'] - 2,
-    marginBottom:    spacing['2'] + 2,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    padding: spacing['4'],
+    marginBottom: spacing['3'],
+    gap: spacing['3'],
   },
   weekBadge: {
-    backgroundColor:   '#eef2ff',
-    borderRadius:      radius.full,
-    paddingVertical:   3,
-    paddingHorizontal: spacing['2'] + 2,
-    alignSelf:         'flex-start',
-    marginBottom:      7,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: colors.primarySubtle,
+    borderRadius: radius.full,
+    paddingVertical: 4,
+    paddingHorizontal: spacing['3'],
+    alignSelf: 'flex-start',
   },
   weekBadgeText: {
-    fontSize:   10,
+    fontSize: typography.size.xs,
     fontWeight: typography.weight.semibold,
-    color:      '#4338ca',
+    color: colors.primary,
   },
   desc: {
-    fontSize:     11,
-    color:        colors.textSecondary,
-    lineHeight:   16,
-    marginBottom: spacing['2'] + 2,
+    fontSize: typography.size.base,
+    color: colors.textPrimary,
+    lineHeight: 22,
+    fontWeight: typography.weight.medium,
+  },
+  progressHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 6,
   },
   statusRow: {
     flexDirection: 'row',
-    alignItems:    'center',
-    gap:           6,
-    marginBottom:  9,
+    alignItems: 'center',
+    gap: 6,
   },
   dot: {
-    width:        8,
-    height:       8,
+    width: 8,
+    height: 8,
     borderRadius: 4,
-  },
-  dotActive: {
     backgroundColor: colors.warning,
   },
   statusText: {
-    fontSize:   11,
+    fontSize: typography.size.sm,
     fontWeight: typography.weight.medium,
-    color:      '#b45309',
+    color: colors.warning,
   },
   daysText: {
-    marginLeft: 'auto',
-    fontSize:   10,
-    color:      colors.textMuted,
+    fontSize: typography.size.sm,
+    color: colors.textMuted,
   },
   buttons: {
     flexDirection: 'row',
-    gap:           7,
-    marginTop:     11,
+    gap: spacing['2'],
+    marginTop: spacing['1'],
   },
   btnComplete: {
-    flex:            2,
+    flex: 2,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
     backgroundColor: colors.primary,
-    borderRadius:    radius.md - 2,
-    paddingVertical: spacing['2'] + 1,
-    alignItems:      'center',
+    borderRadius: radius.md,
+    paddingVertical: spacing['3'],
   },
   btnCompleteText: {
-    color:      colors.textInverse,
-    fontSize:   11,
+    color: colors.textInverse,
+    fontSize: typography.size.sm,
     fontWeight: typography.weight.semibold,
   },
   btnGiveUp: {
-    flex:            1,
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
     backgroundColor: colors.background,
-    borderWidth:     1.5,
-    borderColor:     colors.border,
-    borderRadius:    radius.md - 2,
-    paddingVertical: spacing['2'] + 1,
-    alignItems:      'center',
+    borderWidth: 1.5,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingVertical: spacing['3'],
   },
   btnGiveUpText: {
-    color:    colors.textSecondary,
-    fontSize: 11,
+    color: colors.textSecondary,
+    fontSize: typography.size.sm,
   },
 });

--- a/apps/mobile/src/screens/Challenge/ChallengeScreen.tsx
+++ b/apps/mobile/src/screens/Challenge/ChallengeScreen.tsx
@@ -1,22 +1,30 @@
 import React, { useEffect, useState } from 'react';
 import {
-  View, Text, ScrollView, StyleSheet, TouchableOpacity,
-  SafeAreaView, ActivityIndicator,
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { Ionicons } from '@expo/vector-icons';
 import { useChallengeStore } from '../../store/challengeStore';
-import { ChallengeCard }     from '../../components/ui/ChallengeCard';
+import { ChallengeCard } from '../../components/ui/ChallengeCard';
 import { colors, spacing, typography, radius } from '../../theme';
 import { strings } from '../../content/strings';
+import type { ChallengeStatus } from '@financial-advisor/shared';
 
-function statusBadgeStyle(status: 'ACTIVE' | 'COMPLETED' | 'FAILED') {
-  if (status === 'COMPLETED') return { bg: '#ecfdf5', text: '#065f46' };
-  if (status === 'FAILED')    return { bg: '#fef2f2', text: '#991b1b' };
-  return { bg: '#fef9ec', text: '#92400e' };
+function statusStyle(status: ChallengeStatus) {
+  if (status === 'COMPLETED') return { bg: colors.successSubtle, text: colors.success };
+  if (status === 'FAILED') return { bg: colors.dangerSubtle, text: colors.danger };
+  return { bg: colors.warningSubtle, text: colors.warning };
 }
 
-function statusLabel(status: 'ACTIVE' | 'COMPLETED' | 'FAILED') {
+function statusLabel(status: ChallengeStatus) {
   if (status === 'COMPLETED') return strings.challenge.statusCompleted;
-  if (status === 'FAILED')    return strings.challenge.statusFailed;
+  if (status === 'FAILED') return strings.challenge.statusFailed;
   return strings.challenge.statusActive;
 }
 
@@ -32,7 +40,9 @@ function formatWeekRange(start: string, end: string) {
 }
 
 export default function ChallengeScreen() {
-  const { active, past, loading, fetchChallenges, generateChallenge, updateStatus } = useChallengeStore();
+  const tabBarHeight = useBottomTabBarHeight();
+  const { active, past, loading, fetchChallenges, generateChallenge, updateStatus } =
+    useChallengeStore();
   const [actionLoading, setActionLoading] = useState(false);
 
   useEffect(() => {
@@ -69,11 +79,11 @@ export default function ChallengeScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.safe}>
+    <SafeAreaView edges={['top']} style={[styles.safe, { paddingBottom: tabBarHeight }]}>
       {/* Header */}
       <View style={styles.header}>
         <Text style={styles.title}>{strings.challenge.title}</Text>
-        <Text style={styles.subtitle}>Your AI-generated weekly challenge</Text>
+        <Text style={styles.subtitle}>AI-generated weekly challenge</Text>
       </View>
 
       <ScrollView
@@ -81,9 +91,7 @@ export default function ChallengeScreen() {
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator={false}
       >
-        {loading && !active && (
-          <ActivityIndicator color={colors.primary} style={styles.loader} />
-        )}
+        {loading && !active && <ActivityIndicator color={colors.primary} style={styles.loader} />}
 
         {/* Active challenge */}
         {active ? (
@@ -93,33 +101,46 @@ export default function ChallengeScreen() {
             onGiveUp={handleGiveUp}
             loading={actionLoading}
           />
-        ) : !loading && (
-          <View style={styles.emptyCard}>
-            <Text style={styles.emptyText}>{strings.challenge.empty}</Text>
-            <TouchableOpacity
-              style={[styles.generateBtn, actionLoading && styles.generateBtnDisabled]}
-              onPress={handleGenerate}
-              disabled={actionLoading}
-              activeOpacity={0.85}
-            >
-              {actionLoading
-                ? <ActivityIndicator color={colors.textInverse} />
-                : <Text style={styles.generateBtnText}>{strings.challenge.generateButton}</Text>
-              }
-            </TouchableOpacity>
-          </View>
+        ) : (
+          !loading && (
+            <View style={styles.emptyCard}>
+              <Ionicons name="trophy-outline" size={36} color={colors.textMuted} />
+              <Text style={styles.emptyTitle}>No active challenge</Text>
+              <Text style={styles.emptyBody}>{strings.challenge.empty}</Text>
+              <TouchableOpacity
+                style={[styles.generateBtn, actionLoading && styles.generateBtnDisabled]}
+                onPress={handleGenerate}
+                disabled={actionLoading}
+                activeOpacity={0.85}
+              >
+                {actionLoading ? (
+                  <ActivityIndicator color={colors.textInverse} />
+                ) : (
+                  <>
+                    <Ionicons name="sparkles" size={15} color={colors.textInverse} />
+                    <Text style={styles.generateBtnText}>{strings.challenge.generateButton}</Text>
+                  </>
+                )}
+              </TouchableOpacity>
+            </View>
+          )
         )}
 
         {/* Past challenges */}
         {past.length > 0 && (
           <View style={styles.pastCard}>
             <Text style={styles.pastTitle}>Past challenges</Text>
-            {past.map((c) => {
-              const badge = statusBadgeStyle(c.status);
+            {past.map((c, i) => {
+              const badge = statusStyle(c.status);
               return (
-                <View key={c.id} style={styles.pastRow}>
+                <View
+                  key={c.id}
+                  style={[styles.pastRow, i === past.length - 1 && styles.pastRowLast]}
+                >
                   <View style={styles.pastLeft}>
-                    <Text style={styles.pastName} numberOfLines={1}>{c.description}</Text>
+                    <Text style={styles.pastName} numberOfLines={1}>
+                      {c.description}
+                    </Text>
                     <Text style={styles.pastDate}>{formatWeekRange(c.weekStart, c.weekEnd)}</Text>
                   </View>
                   <View style={[styles.pastBadge, { backgroundColor: badge.bg }]}>
@@ -133,11 +154,15 @@ export default function ChallengeScreen() {
           </View>
         )}
 
-        {/* Next week preview */}
+        {/* Next week */}
         <View style={styles.nextCard}>
-          <Text style={styles.nextTitle}>Next week preview</Text>
+          <View style={styles.nextTitleRow}>
+            <Ionicons name="sparkles" size={13} color={colors.primary} />
+            <Text style={styles.nextTitle}>Next week</Text>
+          </View>
           <Text style={styles.nextBody}>
-            Your AI advisor will generate a new personalised challenge based on your spending patterns.
+            Fina will generate a new personalised challenge based on your spending patterns at the
+            start of each week.
           </Text>
         </View>
 
@@ -149,128 +174,149 @@ export default function ChallengeScreen() {
 
 const styles = StyleSheet.create({
   safe: {
-    flex:            1,
+    flex: 1,
     backgroundColor: colors.background,
   },
   header: {
     backgroundColor: colors.surface,
     paddingHorizontal: spacing['4'],
-    paddingVertical: spacing['3'],
+    paddingTop: spacing['3'],
+    paddingBottom: 14,
     borderBottomWidth: 1,
     borderBottomColor: colors.border,
   },
   title: {
-    fontSize:   21,
+    fontSize: 26,
     fontWeight: typography.weight.bold,
-    color:      colors.textPrimary,
+    color: colors.textPrimary,
+    letterSpacing: -0.3,
   },
   subtitle: {
-    fontSize:  11,
-    color:     colors.textMuted,
+    fontSize: typography.size.sm,
+    color: colors.textMuted,
     marginTop: 2,
   },
   scroll: {
     flex: 1,
   },
   content: {
-    padding: spacing['3'] + 1,
+    padding: spacing['4'],
   },
   loader: {
     marginTop: spacing['8'],
   },
   emptyCard: {
     backgroundColor: colors.surface,
-    borderWidth:     1,
-    borderColor:     colors.border,
-    borderRadius:    radius.lg,
-    padding:         spacing['4'],
-    alignItems:      'center',
-    marginBottom:    spacing['2'] + 2,
-    gap:             spacing['3'],
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    padding: spacing['5'],
+    alignItems: 'center',
+    marginBottom: spacing['3'],
+    gap: spacing['2'],
   },
-  emptyText: {
-    fontSize:  typography.size.sm,
-    color:     colors.textMuted,
+  emptyTitle: {
+    fontSize: typography.size.md,
+    fontWeight: typography.weight.semibold,
+    color: colors.textSecondary,
+    marginTop: spacing['1'],
+  },
+  emptyBody: {
+    fontSize: typography.size.sm,
+    color: colors.textMuted,
     textAlign: 'center',
+    maxWidth: 240,
+    lineHeight: 20,
   },
   generateBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
     backgroundColor: colors.primary,
-    borderRadius:    radius.md,
+    borderRadius: radius.md,
     paddingVertical: spacing['3'],
-    paddingHorizontal: spacing['6'],
-    alignItems:      'center',
+    paddingHorizontal: spacing['5'],
+    marginTop: spacing['1'],
   },
   generateBtnDisabled: {
     opacity: 0.6,
   },
   generateBtnText: {
-    color:      colors.textInverse,
-    fontSize:   typography.size.sm,
+    color: colors.textInverse,
+    fontSize: typography.size.sm,
     fontWeight: typography.weight.semibold,
   },
   pastCard: {
     backgroundColor: colors.surface,
-    borderWidth:     1,
-    borderColor:     colors.border,
-    borderRadius:    radius.md + 1,
-    padding:         spacing['3'] + 1,
-    marginBottom:    spacing['2'] + 2,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    padding: spacing['3'],
+    marginBottom: spacing['3'],
   },
   pastTitle: {
-    fontSize:     12,
-    fontWeight:   typography.weight.bold,
-    color:        colors.textPrimary,
-    marginBottom: spacing['2'] + 1,
+    fontSize: typography.size.sm,
+    fontWeight: typography.weight.bold,
+    color: colors.textPrimary,
+    marginBottom: spacing['2'],
   },
   pastRow: {
-    flexDirection:   'row',
-    justifyContent:  'space-between',
-    alignItems:      'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     paddingVertical: spacing['2'],
     borderBottomWidth: 1,
-    borderBottomColor: '#f1f5f9',
+    borderBottomColor: colors.border,
+  },
+  pastRowLast: {
+    borderBottomWidth: 0,
   },
   pastLeft: {
-    flex:        1,
+    flex: 1,
     marginRight: spacing['2'],
   },
   pastName: {
-    fontSize:   11,
+    fontSize: typography.size.sm,
     fontWeight: typography.weight.medium,
-    color:      colors.textPrimary,
+    color: colors.textPrimary,
   },
   pastDate: {
-    fontSize:  10,
-    color:     colors.textMuted,
-    marginTop: 1,
+    fontSize: typography.size.xs,
+    color: colors.textMuted,
+    marginTop: 2,
   },
   pastBadge: {
-    borderRadius:      radius.full,
-    paddingVertical:   3,
-    paddingHorizontal: spacing['2'] + 1,
+    borderRadius: radius.full,
+    paddingVertical: 3,
+    paddingHorizontal: spacing['2'],
   },
   pastBadgeText: {
-    fontSize:   9,
+    fontSize: typography.size.xs,
     fontWeight: typography.weight.semibold,
   },
   nextCard: {
-    backgroundColor: '#eef2ff',
-    borderRadius:    radius.md,
-    padding:         11,
-    marginBottom:    spacing['2'] + 2,
+    backgroundColor: colors.primarySubtle,
+    borderRadius: radius.lg,
+    padding: spacing['3'],
+    marginBottom: spacing['3'],
+    gap: 6,
+  },
+  nextTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
   },
   nextTitle: {
-    fontSize:     10,
-    fontWeight:   typography.weight.semibold,
-    color:        '#3730a3',
-    marginBottom: 3,
+    fontSize: typography.size.sm,
+    fontWeight: typography.weight.semibold,
+    color: colors.primaryDark,
   },
   nextBody: {
-    fontSize:   11,
-    color:      '#4f46e5',
-    lineHeight: 16,
+    fontSize: typography.size.sm,
+    color: colors.primary,
+    lineHeight: 19,
   },
   bottomPad: {
-    height: 100,
+    height: 24,
   },
 });


### PR DESCRIPTION
## Summary
- Header title 21px → 26px + subtitle at `typography.size.sm`
- Switch to `SafeAreaView` from `react-native-safe-area-context` + `useBottomTabBarHeight()`
- `ChallengeCard`: bumped description to `typography.size.base` + `weight.medium`, week badge uses `colors.primarySubtle` instead of `#eef2ff`, status text uses `colors.warning`, button font to `typography.size.sm`, added checkmark icon on complete button, `daysLeft` label replaces raw day count
- `ChallengeScreen`: `statusBadgeStyle` replaced with `statusStyle()` using semantic tokens (`colors.successSubtle`, `colors.dangerSubtle`, `colors.warningSubtle`)
- Past challenges list: last row no longer has a bottom border, font sizes bumped to `typography.size.sm`
- Next week card: uses `colors.primarySubtle`, icon + title row, body at `typography.size.sm`
- Empty state: icon + title + explanatory body, generate button has sparkles icon

Closes #17
🤖 Generated with [Claude Code](https://claude.com/claude-code)