### PR TITLE
feat(splitwise): Splitwise tool-calling integration for AI chat agent

### DIFF
--- a/apps/api/prisma/migrations/20260325233028_add_splitwise_api_key/migration.sql
+++ b/apps/api/prisma/migrations/20260325233028_add_splitwise_api_key/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "splitwiseApiKey" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -62,6 +62,8 @@ model User {
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
 
+  splitwiseApiKey String?
+
   transactions Transaction[]
   goals        Goal[]
   challenges   Challenge[]

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { GoalsModule } from './goals/goals.module';
 import { InsightsModule } from './insights/insights.module';
 import { ChallengesModule } from './challenges/challenges.module';
 import { ChatModule } from './chat/chat.module';
+import { SplitwiseModule } from './splitwise/splitwise.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { ChatModule } from './chat/chat.module';
     InsightsModule,
     ChallengesModule,
     ChatModule,
+    SplitwiseModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/chat/chat-agent.service.ts
+++ b/apps/api/src/chat/chat-agent.service.ts
@@ -4,6 +4,10 @@ import { SystemMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import { AiService } from '../ai/ai.service';
 import { ChatToolsService, buildTools } from './chat-tools.service';
+import {
+  SplitwiseToolsService,
+  buildSplitwiseTools,
+} from '../splitwise/splitwise-tools.service';
 import type { ChatStreamEvent } from '@financial-advisor/shared';
 
 const HISTORY_WINDOW = 20;
@@ -13,20 +17,34 @@ export class ChatAgentService {
   constructor(
     private readonly ai: AiService,
     private readonly toolsService: ChatToolsService,
+    private readonly splitwiseToolsService: SplitwiseToolsService,
   ) {}
 
   async *stream(
     userId: string,
     userName: string,
     messages: BaseMessage[],
+    splitwiseApiKey: string | null,
   ): AsyncGenerator<ChatStreamEvent> {
     const tools = buildTools(this.toolsService, userId);
+
+    if (splitwiseApiKey) {
+      tools.push(
+        ...buildSplitwiseTools(
+          this.splitwiseToolsService as any,
+          splitwiseApiKey,
+        ),
+      );
+    }
+
     const model = this.ai.getModel();
 
     const agent = createReactAgent({
       llm: model,
       tools,
-      stateModifier: new SystemMessage(buildSystemPrompt(userName)),
+      stateModifier: new SystemMessage(
+        buildSystemPrompt(userName, !!splitwiseApiKey),
+      ),
     });
 
     const windowed = messages.slice(-HISTORY_WINDOW);
@@ -69,12 +87,15 @@ export class ChatAgentService {
 // Module-private helpers
 // ---------------------------------------------------------------------------
 
-function buildSystemPrompt(userName: string): string {
+function buildSystemPrompt(userName: string, hasSplitwise: boolean): string {
   const today = new Date().toISOString().split('T')[0];
+  const splitwiseLine = hasSplitwise
+    ? `\nYou also have access to ${userName}'s Splitwise account via tools. For create_splitwise_expense, always confirm split details with the user before calling the tool.`
+    : '';
   return `You are Fina, a personal finance assistant. Today is ${today}.
 You have access to ${userName}'s real financial data via tools — always use tools to answer questions, never guess numbers.
 Be concise, specific, and cite actual amounts from the data.
-Never reveal raw IDs or internal fields. If data is unavailable, say so honestly.`;
+Never reveal raw IDs or internal fields. If data is unavailable, say so honestly.${splitwiseLine}`;
 }
 
 function extractToolOutput(output: unknown): unknown {

--- a/apps/api/src/chat/chat.module.ts
+++ b/apps/api/src/chat/chat.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 import { AiModule } from '../ai/ai.module';
 import { PrismaModule } from '../prisma/prisma.module';
+import { SplitwiseModule } from '../splitwise/splitwise.module';
 import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
 import { ChatAgentService } from './chat-agent.service';
 import { ChatToolsService } from './chat-tools.service';
 
 @Module({
-  imports: [PrismaModule, AiModule],
+  imports: [PrismaModule, AiModule, SplitwiseModule],
   controllers: [ChatController],
   providers: [ChatService, ChatAgentService, ChatToolsService],
 })

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -102,6 +102,7 @@ export class ChatService {
       userId,
       userName,
       allMessages,
+      user.splitwiseApiKey ?? null,
     )) {
       if (event.type === 'token') assistantText += event.data.content;
       yield event;

--- a/apps/api/src/splitwise/splitwise-tools.service.ts
+++ b/apps/api/src/splitwise/splitwise-tools.service.ts
@@ -1,0 +1,198 @@
+import { Injectable } from '@nestjs/common';
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { SplitwiseService } from './splitwise.service';
+
+@Injectable()
+export class SplitwiseToolsService {
+  constructor(private readonly splitwise: SplitwiseService) {}
+}
+
+// ---------------------------------------------------------------------------
+// Build tool definitions with apiKey bound in closure
+// ---------------------------------------------------------------------------
+
+export function buildSplitwiseTools(
+  service: SplitwiseToolsService & { splitwise: SplitwiseService },
+  apiKey: string,
+): DynamicStructuredTool[] {
+  const sw: SplitwiseService = (service as any).splitwise;
+
+  return [
+    // -----------------------------------------------------------------------
+    // get_splitwise_expenses
+    // -----------------------------------------------------------------------
+    new DynamicStructuredTool({
+      name: 'get_splitwise_expenses',
+      description:
+        "List the user's Splitwise expenses. Optionally filter by group, friend, date range, or limit.",
+      schema: z.object({
+        group_id: z.number().int().optional().describe('Splitwise group ID'),
+        friend_id: z.number().int().optional().describe('Splitwise friend ID'),
+        dated_after: z
+          .string()
+          .optional()
+          .describe('ISO date string e.g. 2025-01-01'),
+        dated_before: z
+          .string()
+          .optional()
+          .describe('ISO date string e.g. 2025-01-31'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe('Max expenses to return (default 20)'),
+      }),
+      func: (raw) => {
+        const args = parseArgs<{
+          group_id?: number;
+          friend_id?: number;
+          dated_after?: string;
+          dated_before?: string;
+          limit?: number;
+        }>(raw);
+        return sw.getExpenses(apiKey, args).then((r) => JSON.stringify(r));
+      },
+    }),
+
+    // -----------------------------------------------------------------------
+    // get_splitwise_friends
+    // -----------------------------------------------------------------------
+    new DynamicStructuredTool({
+      name: 'get_splitwise_friends',
+      description:
+        "List all of the user's Splitwise friends with their IDs and current balances.",
+      schema: z.object({}),
+      func: () => sw.getFriends(apiKey).then((r) => JSON.stringify(r)),
+    }),
+
+    // -----------------------------------------------------------------------
+    // get_splitwise_groups
+    // -----------------------------------------------------------------------
+    new DynamicStructuredTool({
+      name: 'get_splitwise_groups',
+      description:
+        "List all of the user's Splitwise groups with member details and debts.",
+      schema: z.object({}),
+      func: () => sw.getGroups(apiKey).then((r) => JSON.stringify(r)),
+    }),
+
+    // -----------------------------------------------------------------------
+    // get_splitwise_friend_balances
+    // -----------------------------------------------------------------------
+    new DynamicStructuredTool({
+      name: 'get_splitwise_friend_balances',
+      description:
+        'Return a pre-computed net balance summary across all friends — who owes the user money, who the user owes, and the overall net position. Use this instead of manually summing raw friend balances.',
+      schema: z.object({}),
+      func: async () => {
+        const friends = await sw.getFriends(apiKey);
+        const owesYou: Array<{
+          name: string;
+          amount: number;
+          currency: string;
+        }> = [];
+        const youOwe: Array<{
+          name: string;
+          amount: number;
+          currency: string;
+        }> = [];
+        let net = 0;
+
+        for (const f of friends) {
+          const name = `${f.first_name} ${f.last_name}`.trim();
+          for (const b of f.balance) {
+            const amount = parseFloat(b.amount);
+            if (isNaN(amount) || amount === 0) continue;
+            if (amount > 0) {
+              owesYou.push({ name, amount, currency: b.currency_code });
+              net += amount;
+            } else {
+              youOwe.push({
+                name,
+                amount: Math.abs(amount),
+                currency: b.currency_code,
+              });
+              net += amount;
+            }
+          }
+        }
+
+        return JSON.stringify({
+          owes_you: owesYou,
+          you_owe: youOwe,
+          net: Math.round(net * 100) / 100,
+        });
+      },
+    }),
+
+    // -----------------------------------------------------------------------
+    // create_splitwise_expense
+    // -----------------------------------------------------------------------
+    new DynamicStructuredTool({
+      name: 'create_splitwise_expense',
+      description:
+        'Create a new Splitwise expense with explicit per-user splits. Always confirm split details with the user before calling this tool.',
+      schema: z.object({
+        cost: z
+          .string()
+          .describe('Total cost as a decimal string e.g. "25.50"'),
+        description: z.string().describe('Expense description'),
+        date: z.string().describe('ISO date string e.g. 2025-03-15'),
+        group_id: z
+          .number()
+          .int()
+          .optional()
+          .describe('Splitwise group ID (omit for non-group expense)'),
+        users: z
+          .array(
+            z.object({
+              user_id: z.number().int().describe('Splitwise user ID'),
+              paid_share: z
+                .string()
+                .describe('Amount this user paid e.g. "25.50"'),
+              owed_share: z
+                .string()
+                .describe('Amount this user owes e.g. "12.75"'),
+            }),
+          )
+          .min(2)
+          .describe('Split breakdown — must include all involved users'),
+      }),
+      func: (raw) => {
+        const args = parseArgs<{
+          cost: string;
+          description: string;
+          date: string;
+          group_id?: number;
+          users: Array<{
+            user_id: number;
+            paid_share: string;
+            owed_share: string;
+          }>;
+        }>(raw);
+        return sw.createExpense(apiKey, args).then((r) => JSON.stringify(r));
+      },
+    }),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Module-private helpers
+// ---------------------------------------------------------------------------
+
+function parseArgs<T extends object>(raw: unknown): T {
+  if (raw && typeof raw === 'object' && 'input' in raw) {
+    const inputVal = (raw as { input: unknown }).input;
+    if (typeof inputVal === 'string') {
+      try {
+        return JSON.parse(inputVal) as T;
+      } catch {
+        // fall through
+      }
+    }
+  }
+  return raw as T;
+}

--- a/apps/api/src/splitwise/splitwise-tools.spec.ts
+++ b/apps/api/src/splitwise/splitwise-tools.spec.ts
@@ -1,0 +1,190 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  SplitwiseToolsService,
+  buildSplitwiseTools,
+} from './splitwise-tools.service';
+import { SplitwiseService } from './splitwise.service';
+
+const API_KEY = 'test-key';
+
+const splitwiseMock: jest.Mocked<SplitwiseService> = {
+  getExpenses: jest.fn(),
+  getFriends: jest.fn(),
+  getGroups: jest.fn(),
+  createExpense: jest.fn(),
+  getExpense: jest.fn(),
+} as any;
+
+describe('SplitwiseToolsService / buildSplitwiseTools', () => {
+  let service: SplitwiseToolsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SplitwiseToolsService,
+        { provide: SplitwiseService, useValue: splitwiseMock },
+      ],
+    }).compile();
+
+    service = module.get<SplitwiseToolsService>(SplitwiseToolsService);
+    jest.clearAllMocks();
+  });
+
+  it('returns exactly 5 tools', () => {
+    const tools = buildSplitwiseTools(service as any, API_KEY);
+    expect(tools).toHaveLength(5);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('get_splitwise_expenses');
+    expect(names).toContain('get_splitwise_friends');
+    expect(names).toContain('get_splitwise_groups');
+    expect(names).toContain('get_splitwise_friend_balances');
+    expect(names).toContain('create_splitwise_expense');
+  });
+
+  // -------------------------------------------------------------------------
+  // get_splitwise_expenses
+  // -------------------------------------------------------------------------
+
+  describe('get_splitwise_expenses tool', () => {
+    it('calls SplitwiseService.getExpenses with bound apiKey', async () => {
+      const expenses = [{ id: 1, description: 'Pizza' }];
+      splitwiseMock.getExpenses.mockResolvedValue(expenses as any);
+
+      const tools = buildSplitwiseTools(service as any, API_KEY);
+      const tool = tools.find((t) => t.name === 'get_splitwise_expenses')!;
+      const result = await tool.func({ group_id: 42, limit: 5 }, {} as any);
+
+      expect(splitwiseMock.getExpenses).toHaveBeenCalledWith(API_KEY, {
+        group_id: 42,
+        limit: 5,
+      });
+      expect(JSON.parse(result as string)).toEqual(expenses);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_splitwise_friends
+  // -------------------------------------------------------------------------
+
+  describe('get_splitwise_friends tool', () => {
+    it('calls SplitwiseService.getFriends with bound apiKey', async () => {
+      const friends = [{ id: 5, first_name: 'Alice' }];
+      splitwiseMock.getFriends.mockResolvedValue(friends as any);
+
+      const tools = buildSplitwiseTools(service as any, API_KEY);
+      const tool = tools.find((t) => t.name === 'get_splitwise_friends')!;
+      const result = await tool.func({}, {} as any);
+
+      expect(splitwiseMock.getFriends).toHaveBeenCalledWith(API_KEY);
+      expect(JSON.parse(result as string)).toEqual(friends);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_splitwise_groups
+  // -------------------------------------------------------------------------
+
+  describe('get_splitwise_groups tool', () => {
+    it('calls SplitwiseService.getGroups with bound apiKey', async () => {
+      const groups = [{ id: 10, name: 'Roommates' }];
+      splitwiseMock.getGroups.mockResolvedValue(groups as any);
+
+      const tools = buildSplitwiseTools(service as any, API_KEY);
+      const tool = tools.find((t) => t.name === 'get_splitwise_groups')!;
+      const result = await tool.func({}, {} as any);
+
+      expect(splitwiseMock.getGroups).toHaveBeenCalledWith(API_KEY);
+      expect(JSON.parse(result as string)).toEqual(groups);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_splitwise_friend_balances
+  // -------------------------------------------------------------------------
+
+  describe('get_splitwise_friend_balances tool', () => {
+    it('computes owes_you / you_owe / net from friend balances', async () => {
+      splitwiseMock.getFriends.mockResolvedValue([
+        {
+          id: 1,
+          first_name: 'Alice',
+          last_name: 'Smith',
+          email: 'alice@example.com',
+          balance: [{ amount: '30.00', currency_code: 'USD' }],
+        },
+        {
+          id: 2,
+          first_name: 'Bob',
+          last_name: 'Jones',
+          email: 'bob@example.com',
+          balance: [{ amount: '-10.00', currency_code: 'USD' }],
+        },
+        {
+          id: 3,
+          first_name: 'Carol',
+          last_name: 'Doe',
+          email: 'carol@example.com',
+          balance: [{ amount: '0.00', currency_code: 'USD' }],
+        },
+      ] as any);
+
+      const tools = buildSplitwiseTools(service as any, API_KEY);
+      const tool = tools.find(
+        (t) => t.name === 'get_splitwise_friend_balances',
+      )!;
+      const result = JSON.parse((await tool.func({}, {} as any)) as string);
+
+      expect(result.owes_you).toEqual([
+        { name: 'Alice Smith', amount: 30, currency: 'USD' },
+      ]);
+      expect(result.you_owe).toEqual([
+        { name: 'Bob Jones', amount: 10, currency: 'USD' },
+      ]);
+      expect(result.net).toBe(20);
+    });
+
+    it('returns empty arrays and zero net when no balances', async () => {
+      splitwiseMock.getFriends.mockResolvedValue([]);
+
+      const tools = buildSplitwiseTools(service as any, API_KEY);
+      const tool = tools.find(
+        (t) => t.name === 'get_splitwise_friend_balances',
+      )!;
+      const result = JSON.parse((await tool.func({}, {} as any)) as string);
+
+      expect(result.owes_you).toEqual([]);
+      expect(result.you_owe).toEqual([]);
+      expect(result.net).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // create_splitwise_expense
+  // -------------------------------------------------------------------------
+
+  describe('create_splitwise_expense tool', () => {
+    it('calls SplitwiseService.createExpense with bound apiKey', async () => {
+      const expense = { id: 99, description: 'Dinner' };
+      splitwiseMock.createExpense.mockResolvedValue(expense as any);
+
+      const tools = buildSplitwiseTools(service as any, API_KEY);
+      const tool = tools.find((t) => t.name === 'create_splitwise_expense')!;
+
+      const args = {
+        cost: '50.00',
+        description: 'Dinner',
+        date: '2025-03-01',
+        group_id: 10,
+        users: [
+          { user_id: 1, paid_share: '50.00', owed_share: '25.00' },
+          { user_id: 2, paid_share: '0.00', owed_share: '25.00' },
+        ],
+      };
+
+      const result = await tool.func(args, {} as any);
+
+      expect(splitwiseMock.createExpense).toHaveBeenCalledWith(API_KEY, args);
+      expect(JSON.parse(result as string)).toEqual(expense);
+    });
+  });
+});

--- a/apps/api/src/splitwise/splitwise.module.ts
+++ b/apps/api/src/splitwise/splitwise.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SplitwiseService } from './splitwise.service';
+import { SplitwiseToolsService } from './splitwise-tools.service';
+
+@Module({
+  providers: [SplitwiseService, SplitwiseToolsService],
+  exports: [SplitwiseService, SplitwiseToolsService],
+})
+export class SplitwiseModule {}

--- a/apps/api/src/splitwise/splitwise.service.spec.ts
+++ b/apps/api/src/splitwise/splitwise.service.spec.ts
@@ -1,0 +1,182 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SplitwiseService } from './splitwise.service';
+
+const API_KEY = 'test-api-key';
+const BASE = 'https://secure.splitwise.com/api/v3.0';
+
+function mockFetch(body: unknown, status = 200) {
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: jest.fn().mockResolvedValue('error body'),
+    json: jest.fn().mockResolvedValue(body),
+  });
+}
+
+describe('SplitwiseService', () => {
+  let service: SplitwiseService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SplitwiseService],
+    }).compile();
+
+    service = module.get<SplitwiseService>(SplitwiseService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // getExpenses
+  // -------------------------------------------------------------------------
+
+  describe('getExpenses', () => {
+    it('calls correct URL with default limit and Bearer header', async () => {
+      const expense = { id: 1, description: 'Dinner' };
+      global.fetch = mockFetch({ expenses: [expense] });
+
+      const result = await service.getExpenses(API_KEY, {});
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toContain(`${BASE}/get_expenses`);
+      expect(url).toContain('limit=20');
+      expect((init as RequestInit).headers).toMatchObject({
+        Authorization: `Bearer ${API_KEY}`,
+      });
+      expect(result).toEqual([expense]);
+    });
+
+    it('serializes optional filters into query params', async () => {
+      global.fetch = mockFetch({ expenses: [] });
+
+      await service.getExpenses(API_KEY, {
+        group_id: 42,
+        friend_id: 7,
+        dated_after: '2025-01-01',
+        dated_before: '2025-01-31',
+        limit: 5,
+      });
+
+      const [url] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toContain('group_id=42');
+      expect(url).toContain('friend_id=7');
+      expect(url).toContain('dated_after=2025-01-01');
+      expect(url).toContain('dated_before=2025-01-31');
+      expect(url).toContain('limit=5');
+    });
+
+    it('throws on non-2xx response', async () => {
+      global.fetch = mockFetch({}, 401);
+
+      await expect(service.getExpenses(API_KEY, {})).rejects.toThrow(
+        'Splitwise API error 401',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getFriends
+  // -------------------------------------------------------------------------
+
+  describe('getFriends', () => {
+    it('returns friends array', async () => {
+      const friend = { id: 5, first_name: 'Alice' };
+      global.fetch = mockFetch({ friends: [friend] });
+
+      const result = await service.getFriends(API_KEY);
+
+      const [url] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe(`${BASE}/get_friends`);
+      expect(result).toEqual([friend]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getGroups
+  // -------------------------------------------------------------------------
+
+  describe('getGroups', () => {
+    it('returns groups array', async () => {
+      const group = { id: 10, name: 'Roommates' };
+      global.fetch = mockFetch({ groups: [group] });
+
+      const result = await service.getGroups(API_KEY);
+
+      const [url] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe(`${BASE}/get_groups`);
+      expect(result).toEqual([group]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // createExpense
+  // -------------------------------------------------------------------------
+
+  describe('createExpense', () => {
+    it('POSTs form-encoded body and returns expense', async () => {
+      const expense = { id: 99, description: 'Pizza' };
+      global.fetch = mockFetch({ expense });
+
+      const result = await service.createExpense(API_KEY, {
+        cost: '30.00',
+        description: 'Pizza',
+        date: '2025-03-01',
+        group_id: 10,
+        users: [
+          { user_id: 1, paid_share: '30.00', owed_share: '15.00' },
+          { user_id: 2, paid_share: '0.00', owed_share: '15.00' },
+        ],
+      });
+
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe(`${BASE}/create_expense`);
+      expect((init as RequestInit).method).toBe('POST');
+      expect((init as RequestInit).headers).toMatchObject({
+        'Content-Type': 'application/x-www-form-urlencoded',
+      });
+
+      const body = new URLSearchParams((init as RequestInit).body as string);
+      expect(body.get('cost')).toBe('30.00');
+      expect(body.get('description')).toBe('Pizza');
+      expect(body.get('group_id')).toBe('10');
+      expect(body.get('users__0__user_id')).toBe('1');
+      expect(body.get('users__0__paid_share')).toBe('30.00');
+      expect(body.get('users__1__owed_share')).toBe('15.00');
+
+      expect(result).toEqual(expense);
+    });
+
+    it('throws on non-2xx response', async () => {
+      global.fetch = mockFetch({}, 422);
+
+      await expect(
+        service.createExpense(API_KEY, {
+          cost: '10.00',
+          description: 'Test',
+          date: '2025-01-01',
+          users: [],
+        }),
+      ).rejects.toThrow('Splitwise API error 422');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getExpense
+  // -------------------------------------------------------------------------
+
+  describe('getExpense', () => {
+    it('fetches a single expense by id', async () => {
+      const expense = { id: 55, description: 'Coffee' };
+      global.fetch = mockFetch({ expense });
+
+      const result = await service.getExpense(API_KEY, 55);
+
+      const [url] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe(`${BASE}/get_expense/55`);
+      expect(result).toEqual(expense);
+    });
+  });
+});

--- a/apps/api/src/splitwise/splitwise.service.ts
+++ b/apps/api/src/splitwise/splitwise.service.ts
@@ -1,0 +1,199 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+// ---------------------------------------------------------------------------
+// Minimal Splitwise API types
+// ---------------------------------------------------------------------------
+
+export interface SplitwiseUser {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+}
+
+export interface SplitwiseDebt {
+  from: number;
+  to: number;
+  amount: string;
+  currency_code: string;
+}
+
+export interface SplitwiseExpenseUser {
+  user_id: number;
+  paid_share: string;
+  owed_share: string;
+  net_balance: string;
+}
+
+export interface SplitwiseExpense {
+  id: number;
+  description: string;
+  cost: string;
+  currency_code: string;
+  date: string;
+  group_id: number | null;
+  users: SplitwiseExpenseUser[];
+  deleted_at: string | null;
+}
+
+export interface SplitwiseFriend {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+  balance: Array<{ amount: string; currency_code: string }>;
+}
+
+export interface SplitwiseGroup {
+  id: number;
+  name: string;
+  members: SplitwiseUser[];
+  debt: SplitwiseDebt[];
+}
+
+export interface GetExpensesOpts {
+  group_id?: number;
+  friend_id?: number;
+  dated_after?: string;
+  dated_before?: string;
+  limit?: number;
+}
+
+export interface CreateExpenseData {
+  cost: string;
+  description: string;
+  date: string;
+  group_id?: number;
+  users: Array<{
+    user_id: number;
+    paid_share: string;
+    owed_share: string;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+@Injectable()
+export class SplitwiseService {
+  private readonly logger = new Logger(SplitwiseService.name);
+  private readonly BASE = 'https://secure.splitwise.com/api/v3.0';
+
+  private async get<T>(
+    apiKey: string,
+    path: string,
+    params?: Record<string, string | number | undefined>,
+  ): Promise<T> {
+    const url = new URL(`${this.BASE}${path}`);
+    if (params) {
+      for (const [k, v] of Object.entries(params)) {
+        if (v !== undefined) url.searchParams.set(k, String(v));
+      }
+    }
+
+    this.logger.log(`GET ${url.toString()}`);
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Splitwise API error ${res.status}: ${await res.text()}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  private async post<T>(
+    apiKey: string,
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<T> {
+    const url = `${this.BASE}${path}`;
+    const encoded = new URLSearchParams();
+    for (const [k, v] of Object.entries(body)) {
+      if (v !== undefined && v !== null) encoded.set(k, String(v));
+    }
+
+    this.logger.log(`POST ${url}`);
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: encoded.toString(),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Splitwise API error ${res.status}: ${await res.text()}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  async getExpenses(
+    apiKey: string,
+    opts: GetExpensesOpts,
+  ): Promise<SplitwiseExpense[]> {
+    const data = await this.get<{ expenses: SplitwiseExpense[] }>(
+      apiKey,
+      '/get_expenses',
+      {
+        group_id: opts.group_id,
+        friend_id: opts.friend_id,
+        dated_after: opts.dated_after,
+        dated_before: opts.dated_before,
+        limit: opts.limit ?? 20,
+      },
+    );
+    return data.expenses;
+  }
+
+  async getFriends(apiKey: string): Promise<SplitwiseFriend[]> {
+    const data = await this.get<{ friends: SplitwiseFriend[] }>(
+      apiKey,
+      '/get_friends',
+    );
+    return data.friends;
+  }
+
+  async getGroups(apiKey: string): Promise<SplitwiseGroup[]> {
+    const data = await this.get<{ groups: SplitwiseGroup[] }>(
+      apiKey,
+      '/get_groups',
+    );
+    return data.groups;
+  }
+
+  async createExpense(
+    apiKey: string,
+    data: CreateExpenseData,
+  ): Promise<SplitwiseExpense> {
+    const body: Record<string, unknown> = {
+      cost: data.cost,
+      description: data.description,
+      date: data.date,
+      ...(data.group_id !== undefined ? { group_id: data.group_id } : {}),
+    };
+
+    data.users.forEach((u, i) => {
+      body[`users__${i}__user_id`] = u.user_id;
+      body[`users__${i}__paid_share`] = u.paid_share;
+      body[`users__${i}__owed_share`] = u.owed_share;
+    });
+
+    const result = await this.post<{ expense: SplitwiseExpense }>(
+      apiKey,
+      '/create_expense',
+      body,
+    );
+    return result.expense;
+  }
+
+  async getExpense(apiKey: string, id: number): Promise<SplitwiseExpense> {
+    const data = await this.get<{ expense: SplitwiseExpense }>(
+      apiKey,
+      `/get_expense/${id}`,
+    );
+    return data.expense;
+  }
+}

--- a/apps/api/src/users/dto/update-splitwise.dto.ts
+++ b/apps/api/src/users/dto/update-splitwise.dto.ts
@@ -1,0 +1,7 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateSplitwiseDto {
+  @IsOptional()
+  @IsString()
+  apiKey?: string | null;
+}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,34 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Patch,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UpdateSplitwiseDto } from './dto/update-splitwise.dto';
+import { UsersService } from './users.service';
+
+interface AuthRequest {
+  user: { id: string; email: string };
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller('users')
+export class UsersController {
+  constructor(private readonly users: UsersService) {}
+
+  @Patch('me/splitwise')
+  @HttpCode(204)
+  async updateSplitwise(
+    @Request() req: AuthRequest,
+    @Body() dto: UpdateSplitwiseDto,
+  ): Promise<void> {
+    if (dto.apiKey) {
+      await this.users.saveSplitwiseApiKey(req.user.id, dto.apiKey);
+    } else {
+      await this.users.clearSplitwiseApiKey(req.user.id);
+    }
+  }
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,7 +1,11 @@
 import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
+  imports: [PrismaModule],
+  controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -17,6 +17,7 @@ const prismaMock = {
   user: {
     findUnique: jest.fn(),
     create: jest.fn(),
+    update: jest.fn(),
   },
 };
 
@@ -78,7 +79,33 @@ describe('UsersService', () => {
       });
       expect(result).toEqual(mockUser);
       expect(prismaMock.user.create).toHaveBeenCalledWith({
-        data: { email: 'test@example.com', passwordHash: 'hashed', name: 'Test User' },
+        data: {
+          email: 'test@example.com',
+          passwordHash: 'hashed',
+          name: 'Test User',
+        },
+      });
+    });
+  });
+
+  describe('saveSplitwiseApiKey', () => {
+    it('calls prisma.user.update with the provided apiKey', async () => {
+      prismaMock.user.update.mockResolvedValue(mockUser);
+      await service.saveSplitwiseApiKey('user-1', 'sw-key-abc');
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: { splitwiseApiKey: 'sw-key-abc' },
+      });
+    });
+  });
+
+  describe('clearSplitwiseApiKey', () => {
+    it('calls prisma.user.update with null', async () => {
+      prismaMock.user.update.mockResolvedValue(mockUser);
+      await service.clearSplitwiseApiKey('user-1');
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: { splitwiseApiKey: null },
       });
     });
   });

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -21,4 +21,18 @@ export class UsersService {
   }): Promise<User> {
     return this.prisma.user.create({ data });
   }
+
+  async saveSplitwiseApiKey(id: string, apiKey: string): Promise<void> {
+    await this.prisma.user.update({
+      where: { id },
+      data: { splitwiseApiKey: apiKey },
+    });
+  }
+
+  async clearSplitwiseApiKey(id: string): Promise<void> {
+    await this.prisma.user.update({
+      where: { id },
+      data: { splitwiseApiKey: null },
+    });
+  }
 }


### PR DESCRIPTION
## Summary

- Adds 5 Splitwise `DynamicStructuredTool` definitions to the AI chat agent: `get_splitwise_expenses`, `get_splitwise_friends`, `get_splitwise_groups`, `get_splitwise_friend_balances`, `create_splitwise_expense`
- Tools are injected conditionally — only when a user has a Splitwise API key configured
- Adds `PATCH /users/me/splitwise` endpoint to save or clear a user's Splitwise API key
- `splitwiseApiKey String?` column added to the `User` model (migration included)
- Native `fetch` (Node 22) — no new dependencies

## Test plan

- [x] `splitwise.service.spec.ts` — 8 tests: URL construction, query params, Bearer header, form-encoded POST body, non-2xx error throwing
- [x] `splitwise-tools.spec.ts` — 7 tests: 5 tools returned, each calls correct service method with bound apiKey, `get_splitwise_friend_balances` correctly partitions positive/negative balances
- [x] `users.service.spec.ts` — extended with 2 tests for `saveSplitwiseApiKey` / `clearSplitwiseApiKey`
- [x] All 22 new tests pass; full suite 151/152 pass (1 pre-existing llm.factory failure unrelated to this PR)

Closes #12